### PR TITLE
Epic: サンドボックスの分離単位を epic に揃え、コンテナのリークと compose・イメージの穴を塞ぐ (v0.11.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dev-workflow",
   "displayName": "Dev Workflow",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "3エージェント自律開発ワークフロー。Docker sandbox内でplanner・generator・evaluatorによる仕様策定から自律実装まで。",
   "author": {
     "name": "masatoImayama",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "3エージェント自律開発ワークフロー。planner・generator・evaluatorが仕様策定から自律実装までを担う。",
   "author": {
     "name": "masatoImayama",

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 # 設定ファイル・ドキュメントもUTF-8/LFで統一する
 *.json text eol=lf
 *.md text eol=lf
+
+# Dockerfile.dev もLFで統一する（docker build自体はCRLFでも動くが、他ファイルとの一貫性のため）
+Dockerfile* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,9 @@
+# .gitattributes自身もLFで統一する。
+# 自己参照ルールが無いと、このファイル自体がCRLF化され、git のパターン解決
+# （git check-attr 等）が壊れる（実際に発生した障害。行末の\rがパターン文字列に
+# 混入し、以下の *.sh / *.toml のルールごと機能しなくなった）。
+.gitattributes text eol=lf
+
 # シェルスクリプトは必ずLFでチェックアウトする。
 # Windowsのcore.autocrlf=trueでCRLFに変換されると、行末の\rが文字列に混入し
 # フックスクリプトが誤動作する。
@@ -6,6 +12,12 @@
 # 設定ファイル・ドキュメントもUTF-8/LFで統一する
 *.json text eol=lf
 *.md text eol=lf
+
+# Codexエージェント定義（オーバーレイ・生成物）もLFで統一する。
+# *.shと同じ理由・同じ障害クラス: core.autocrlf=trueの環境でCRLF化されると、
+# adapters/codex/build.shのinclude展開（1行ずつのcase一致）が壊れ、
+# build.sh --checkが生成物を誤ってSTALEと判定する。
+*.toml text eol=lf
 
 # Dockerfile.dev もLFで統一する（docker build自体はCRLFでも動くが、他ファイルとの一貫性のため）
 Dockerfile* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Claude Code / dev-workflow のローカル作業領域
+.claude/worktrees/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,9 @@
+# dev-workflow: このリポジトリ自身を検証するための開発用サンドボックスイメージ
+#
+# tests/run-tests.sh は Docker を一切使わない（bash -n / shellcheck / --print-plan の
+# ドライラン出力を検証するだけ）ため、Docker CLI はイメージに含めない。
+FROM alpine:3.20
+
+RUN apk add --no-cache bash git shellcheck
+
+WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ compose モードで exec するサービス名は `DEV_WORKFLOW_COMPOSE_SERVICE
 | コマンド | 動作 |
 | --- | --- |
 | `--down` | 現在の repo + epic のコンテナ1個を削除する（キャッシュ volume は残す）。**compose モードのときは** `docker compose -p <project> --project-directory <root> -f <compose_file> down` で現在の project を落とす |
-| `--down --all` | 現在のリポジトリに属する管理コンテナをすべて削除する（削除前に対象名を列挙表示。label が無い旧命名の残骸も、マウント元がリポジトリルート配下かで判定して回収する）。**compose モードのときは** `dw-<repo>` 接頭辞を持つ compose project も列挙表示のうえすべて down する |
+| `--down --all` | 現在のリポジトリに属する管理コンテナをすべて削除する（削除前に対象名を列挙表示。label が無い旧命名の残骸も、マウント元がリポジトリルート配下かで判定して回収する）。**compose モードのときは** `com.docker.compose.project.working_dir` label（＝ `--project-directory` に渡した値）を正規化してリポジトリルート配下と判定できた compose project だけを列挙表示のうえすべて down する（project 名の接頭辞一致では他リポジトリの project を巻き込むため使わない）。リポジトリ外 worktree のフォールバック実行で起動した project は working_dir がリポジトリルート外になるため対象に含まれない |
 | `--ls` | 管理コンテナを一覧表示する（NAME / REPO / EPIC / IMAGE / STATUS / CREATED。他リポジトリ分も含む）。**compose モードのときは** compose project の一覧（PROJECT / STATUS）も併せて表示する |
 | `--reset-cache [--force]` | キャッシュ volume を削除する（下記「作用範囲」を参照） |
 | `--rebuild` | イメージを強制再ビルドし、コンテナも作り直してからコマンドを実行する |

--- a/README.md
+++ b/README.md
@@ -325,6 +325,23 @@ DEV_WORKFLOW_DOCKERFILE=path                # 使用する Dockerfile（既定: 
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-sandbox.sh" --print
 ```
 
+### 分離単位（コンテナ = epic / キャッシュ = リポジトリ / イメージ = Dockerfileのhash）
+
+3つの資源はそれぞれ異なる単位で分離・共有されます。
+
+| 資源 | 分離・共有の単位 | 命名 |
+| --- | --- | --- |
+| コンテナ | **epic 単位** | `dw-sandbox-<repo>[-<epic>]` |
+| キャッシュ volume | **リポジトリ単位**（epic 間で共有） | `dw-cache-<repo>-<path>` |
+| イメージ | **Dockerfile 内容の hash 単位** | `dev-sandbox:<repo>-<hash8>` |
+
+バインドマウントはリポジトリルートに固定しているため、generator の isolation worktree
+（`.claude/worktrees/agent-*`）や epic worktree がいくつ増えてもコンテナは epic あたり1個のままです。
+**あえて非対称にしています**: キャッシュだけリポジトリ単位で共有し続けるのは、それが v0.10.0 の性能改善
+（40秒→17秒）の本体であり、epic 単位にすると新しい epic が毎回コールドスタートに戻ってしまうためです。
+非対称であることの唯一の実害は `--reset-cache` の誤爆（他 epic のキャッシュまで巻き込む）なので、
+そこだけを running コンテナ検出のガードで潰しています（後述）。
+
 ### サンドボックスへのコマンド投入
 
 `docker run` を直接組み立てず、`sandbox-exec.sh` を使います。
@@ -332,18 +349,17 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-sandbox.sh" --print
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 'make test'
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --warm 'go build ./...'
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --down          # 常駐コンテナを削除
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --reset-cache   # キャッシュ volume も削除
 ```
 
 このスクリプトが引き受けること:
 
 | 項目 | 内容 |
 | --- | --- |
+| イメージの解決とビルド | `Dockerfile.dev` があれば内容の hash でタグ付けして自動ビルドする（`DEV_WORKFLOW_DOCKER_IMAGE` 指定時はビルドしない） |
 | ビルドキャッシュの永続化 | `docker run --rm` はコンテナ層ごとキャッシュを毎回捨てる。言語ごとのキャッシュディレクトリを named volume 化して次回に残す |
-| コンテナの再利用 | Epic単位で常駐させ `docker exec` で叩き、起動オーバーヘッドを消す |
+| コンテナの再利用 | epic単位で常駐させ `docker exec` で叩き、起動オーバーヘッドを消す。既存コンテナのマウント元・イメージIDが期待値と異なれば削除して作り直す |
 | Windows のパス変換対策 | Git Bash（MSYS）は `-w /workspace` を `C:/Program Files/Git/workspace` に変換して `docker run` を失敗させる |
-| イメージタグの安定化 | タグをリポジトリ名基準にし、worktree ごとに同じイメージをビルドし直す事故を防ぐ |
+| イメージタグの安定化 | タグをリポジトリ名 + Dockerfile 内容の hash にし、worktree ごとに同じイメージをビルドし直す事故を防ぐ |
 
 終了コードは実行したコマンドのものがそのまま返るので、機械的ゲートの判定に使えます。
 
@@ -354,6 +370,133 @@ compose モードで exec するサービス名は `DEV_WORKFLOW_COMPOSE_SERVICE
 > **待ち時間の主因はコンパイルではなくバインドマウントのI/O**（Windows 実測）。
 > フルツリーを走査するコマンドは1回ごとに走査コストを払うため、
 > **ビルド・vet・テストを別々に呼ばず1回にまとめる**ことが最も効きます。
+
+### ライフサイクル操作
+
+| コマンド | 動作 |
+| --- | --- |
+| `--down` | 現在の repo + epic のコンテナ1個を削除する（キャッシュ volume は残す） |
+| `--down --all` | 現在のリポジトリに属する管理コンテナをすべて削除する（削除前に対象名を列挙表示。label が無い旧命名の残骸も、マウント元がリポジトリルート配下かで判定して回収する） |
+| `--ls` | 管理コンテナを一覧表示する（NAME / REPO / EPIC / IMAGE / STATUS / CREATED。他リポジトリ分も含む） |
+| `--reset-cache [--force]` | キャッシュ volume を削除する（下記「作用範囲」を参照） |
+| `--rebuild` | イメージを強制再ビルドし、コンテナも作り直してからコマンドを実行する |
+| `--print-plan` | docker に一切触れず、解決結果を `key=value` 形式で表示するドライラン（下記） |
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --down
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --down --all
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --ls
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --reset-cache
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --rebuild 'make test'
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --print-plan
+```
+
+#### `--reset-cache` の作用範囲はリポジトリ全体（epicではない）
+
+キャッシュ volume はリポジトリ単位で共有しているため、`--reset-cache` は**現在の epic だけでなく
+同一リポジトリの全 epic のキャッシュを削除**します。誤爆を防ぐため:
+
+1. 削除対象の volume 名をすべて列挙表示します（成否によらず必ず表示）。
+2. 同一リポジトリの管理コンテナが**1つでも running なら中断**し、`--force` の指定を促します
+   （他 epic が実行中にキャッシュを壊さないためのガード）。
+3. `--force` を指定した場合のみ、running なコンテナがあっても実行します。
+
+#### `--rebuild` の使いどころ
+
+イメージタグは `Dockerfile.dev` の内容の hash（`git hash-object` の先頭8文字）から自動的に決まるため、
+`Dockerfile.dev` 自体を編集すれば自動的に別タグになり、再ビルドされます。
+しかし hash は **Dockerfile の内容しか見ない**ため、`COPY go.mod .` のように Dockerfile がコピーする
+対象ファイル（`go.mod` / `package.json` 等）だけを変更した場合は、タグが変わらず古い内容のイメージが
+再利用されてしまいます。この逃げ道が `--rebuild` です。内容に変更が無くても強制的に
+`docker build` からやり直し、コンテナも作り直します。
+
+#### `--print-plan`（ドライラン）
+
+docker に一切触れず、解決結果を `key=value` 形式で標準出力に表示して終了します（exit 0）。
+人間のデバッグ手段としても、CI・テストでの検証手段としても使えます。
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --print-plan
+```
+
+出力キー:
+
+| キー | 内容 |
+| --- | --- |
+| `mode` | `dockerfile` / `compose` / `none` |
+| `repo` | リポジトリ名（`basename(REPO_ROOT)`。worktree名は使わない） |
+| `epic` | epic 識別子（`--epic` または `DEV_WORKFLOW_EPIC`。無ければ空） |
+| `repo_root` | ホスト側のリポジトリルート |
+| `mount_source` | マウント元（dockerfileモード時） |
+| `mount_target` | マウント先（常に `/workspace`） |
+| `workdir` | コンテナ内の作業ディレクトリ（リポジトリルートからの相対パスを反映） |
+| `rel_path` | リポジトリルートからの相対パス（ルート直下なら空） |
+| `fallback` | `1` ならリポジトリ外worktreeのフォールバック中（`0`が通常） |
+| `container` | コンテナ名 |
+| `image` | イメージタグ |
+| `dockerfile` | 使用する Dockerfile のパス（dockerfileモード時） |
+| `build_context` | ビルドコンテキスト（dockerfileモード時） |
+| `compose_file` / `compose_project` / `compose_service` | composeモード時の設定 |
+| `cache_volume` | `<volume名>:<コンテナ内パス>`（キャッシュパスの数だけ複数行） |
+
+### compose モード
+
+`docker-compose.dev.yml` を使う場合、compose ファイルは次の要求仕様を満たす必要があります。
+
+- **常駐サービス名**: 既定 `app`（`DEV_WORKFLOW_COMPOSE_SERVICE` で変更可）
+- **マウント**: 当該サービスが `.:/workspace` をマウントすること
+  （異なるマウント先にする場合は `DEV_WORKFLOW_COMPOSE_WORKDIR` で上書きする）
+- **長時間常駐**: `sleep infinity` 等でプロセスが終了しないこと
+  （running でなければ `sandbox-exec.sh` が `up -d` を試み、それでも起動しなければ原因の分かる
+  エラーで停止する）
+
+呼び出しは `docker compose -p <PROJECT> --project-directory <HOST_ROOT> -f <compose_file> ...` で行い、
+`--project-directory` をリポジトリルートに固定することで、compose ファイル内の相対マウント（`.`）が
+どの worktree から叩いても同じツリーを指すようにしています。
+
+**既知の限界**: compose ファイルが `container_name:` または固定ホストポート（例: `- "8080:8080"`）を
+使っていると、`-p` によるプロジェクト名の分離では解決できない衝突が起き、**epic の並行実行ができません**。
+`sandbox-exec.sh` はこれを検出して stderr に警告しますが、自動では直せません。
+`container_name:` を使わない・ホストポートは固定せずコンテナ側ポートのみ指定する、で回避してください。
+
+### Windows の CRLF に注意
+
+このリポジトリは `.gitattributes` で以下を LF 固定しています。
+
+```
+*.sh text eol=lf
+*.toml text eol=lf
+.gitattributes text eol=lf
+```
+
+Windows の `core.autocrlf=true` 環境では、これが無いとシェルスクリプトが CRLF でチェックアウトされ、
+行末の `\r` が文字列に混入して `syntax error near unexpected token $'{\r'` のような形で壊れます
+（`.gitattributes` 自身も対象にしないと、そのファイル自体がCRLF化されて `git check-attr` の
+パターン解決ごと壊れるため、自己参照ルールも必須です）。
+
+**注意: `.gitattributes` にルールを追加しただけでは、既にリポジトリにコミット済みのファイルは
+遡って正規化されません。** 新しいルールを追加した直後は、次のコマンドで既存のワーキングツリーを
+再正規化する必要があります（本 Epic で実際にこれを踏みました）。
+
+```bash
+git rm --cached -r .
+git reset --hard
+```
+
+新規にシェルスクリプトを追加する場合は、`.gitattributes` に対象パターンが含まれているか確認してください。
+
+### 環境変数一覧
+
+```bash
+DEV_WORKFLOW_DOCKER_IMAGE=my-image:tag       # 既存イメージを使う（ビルドしない）
+DEV_WORKFLOW_DOCKER_COMPOSE_FILE=path.yml    # 使用する compose ファイル
+DEV_WORKFLOW_DOCKERFILE=path                 # 使用する Dockerfile（既定: Dockerfile.dev）
+DEV_WORKFLOW_CACHE_PATHS="/path1 /path2"     # volume化するコンテナ内パス（スペース区切り）
+DEV_WORKFLOW_EPIC=epic259                    # --epic 未指定時に参照する epic 識別子
+DEV_WORKFLOW_COMPOSE_SERVICE=app             # composeモードでexecするサービス名
+DEV_WORKFLOW_COMPOSE_WORKDIR=/workspace      # composeモードでのコンテナ内マウント先の基点
+READABILITY_STDIN_TIMEOUT=5                  # 可読性ガードが引数なし・非tty時にstdinを待つ上限秒数
+```
 
 ## Slack通知
 

--- a/README.md
+++ b/README.md
@@ -375,9 +375,9 @@ compose モードで exec するサービス名は `DEV_WORKFLOW_COMPOSE_SERVICE
 
 | コマンド | 動作 |
 | --- | --- |
-| `--down` | 現在の repo + epic のコンテナ1個を削除する（キャッシュ volume は残す） |
-| `--down --all` | 現在のリポジトリに属する管理コンテナをすべて削除する（削除前に対象名を列挙表示。label が無い旧命名の残骸も、マウント元がリポジトリルート配下かで判定して回収する） |
-| `--ls` | 管理コンテナを一覧表示する（NAME / REPO / EPIC / IMAGE / STATUS / CREATED。他リポジトリ分も含む） |
+| `--down` | 現在の repo + epic のコンテナ1個を削除する（キャッシュ volume は残す）。**compose モードのときは** `docker compose -p <project> --project-directory <root> -f <compose_file> down` で現在の project を落とす |
+| `--down --all` | 現在のリポジトリに属する管理コンテナをすべて削除する（削除前に対象名を列挙表示。label が無い旧命名の残骸も、マウント元がリポジトリルート配下かで判定して回収する）。**compose モードのときは** `dw-<repo>` 接頭辞を持つ compose project も列挙表示のうえすべて down する |
+| `--ls` | 管理コンテナを一覧表示する（NAME / REPO / EPIC / IMAGE / STATUS / CREATED。他リポジトリ分も含む）。**compose モードのときは** compose project の一覧（PROJECT / STATUS）も併せて表示する |
 | `--reset-cache [--force]` | キャッシュ volume を削除する（下記「作用範囲」を参照） |
 | `--rebuild` | イメージを強制再ビルドし、コンテナも作り直してからコマンドを実行する |
 | `--print-plan` | docker に一切触れず、解決結果を `key=value` 形式で表示するドライラン（下記） |
@@ -452,12 +452,19 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic259 --print-plan
 
 呼び出しは `docker compose -p <PROJECT> --project-directory <HOST_ROOT> -f <compose_file> ...` で行い、
 `--project-directory` をリポジトリルートに固定することで、compose ファイル内の相対マウント（`.`）が
-どの worktree から叩いても同じツリーを指すようにしています。
+どの worktree から叩いても同じツリーを指すようにしています。`PROJECT`（`dw-<repo>[-<epic>]`）は
+コンテナ名と同じ元から作るため、リポジトリ外に作られた worktree（フォールバック時）はコンテナ名・
+project 名の両方が epic 共有のものと分離されます。既存サービスが running でもマウント元が期待値と
+異なれば削除して作り直すため、別ツリーのファイルへ静かに exec してしまう経路はありません。
 
 **既知の限界**: compose ファイルが `container_name:` または固定ホストポート（例: `- "8080:8080"`）を
 使っていると、`-p` によるプロジェクト名の分離では解決できない衝突が起き、**epic の並行実行ができません**。
 `sandbox-exec.sh` はこれを検出して stderr に警告しますが、自動では直せません。
 `container_name:` を使わない・ホストポートは固定せずコンテナ側ポートのみ指定する、で回避してください。
+
+**後片付け**: compose モードで起動されたコンテナは通常の `dw-sandbox-*` という名前を持たないため、
+`--down` / `--down --all` / `--ls` はいずれも `docker compose ... down`（`-p` / `--project-directory` 付き）
+を使って対応します。詳細は上記「ライフサイクル操作」を参照してください。
 
 ### Windows の CRLF に注意
 

--- a/agents/evaluator.md
+++ b/agents/evaluator.md
@@ -379,16 +379,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/agents/evaluator.md
+++ b/agents/evaluator.md
@@ -130,15 +130,24 @@ gh issue list --label task --state closed --search "[epic番号]" --json number,
 
 ### 4. テスト実行（サンドボックス内）
 
-サンドボックス内でテストを実行し、全て通ることを確認する:
+サンドボックスへのコマンド投入は**必ず `sandbox-exec.sh` 経由で行う。** `docker run` や
+`docker compose exec` を直接組み立ててはならない。イメージの解決・ビルド・コンテナの
+再利用・compose サービスの起動はすべて `sandbox-exec.sh` に集約されている。
+
+必要なら事前に `--print-plan` で解決結果（mode / container / image / compose_* 等）を
+確認できる（docker には一切触れず、exit 0 で終了する）:
 
 ```bash
-# Dockerfile.dev ベースの場合
-docker run --rm -v "$(pwd):/workspace" -w /workspace "dev-sandbox:[project]" [test-command]
-
-# docker-compose.dev.yml ベースの場合
-docker compose -f docker-compose.dev.yml exec app [test-command]
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+テストは `--epic` を渡して実行する（Epic 単位でコンテナ・キャッシュが共有される）:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" '[test-command]'
+```
+
+全て通ることを確認する。
 
 ## 重要度の基準
 

--- a/agents/generator.md
+++ b/agents/generator.md
@@ -370,16 +370,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/agents/generator.md
+++ b/agents/generator.md
@@ -85,6 +85,25 @@ gh issue view "$TASK_NUMBER"
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" '[test-command]'
 ```
 
+#### `--epic` を必ず渡す
+
+呼び出し時は**必ず `--epic` を渡す**（または `DEV_WORKFLOW_EPIC` 環境変数を設定して尊重する）。
+分離の単位は epic であり、`--epic` を渡し忘れると自分の worktree 専用の別コンテナが
+新たに立ち上がってしまい、epic 内の他タスクと同じコンテナ・同じキャッシュを共有できない。
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic3 '[test-command]'
+```
+
+#### シェルスクリプトを新規生成したら `.gitattributes` を確認する
+
+Windows（`core.autocrlf=true`）で生成した `.sh` は CRLF になり、サンドボックス
+（Linuxコンテナ）内で `syntax error near unexpected token $'{\r'` のように、
+原因が分かりにくい形で失敗する。`.sh` を新規生成したら対象プロジェクトの
+`.gitattributes` に `*.sh text eol=lf` があるか確認し、無ければ追加すること。
+`check-prerequisites.sh` がセッション開始時にこの条件を検出して警告するが、
+警告はブロックしないため、生成側でも確認を徹底する。
+
 #### コマンドは1回にまとめる
 
 **ビルド・vet・テストを別々に呼び出してはならない。** サンドボックスはソースツリーを

--- a/agents/planner.md
+++ b/agents/planner.md
@@ -271,16 +271,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/codex-agents/evaluator.toml
+++ b/codex-agents/evaluator.toml
@@ -136,15 +136,24 @@ gh issue list --label task --state closed --search "[epic番号]" --json number,
 
 ### 4. テスト実行（サンドボックス内）
 
-サンドボックス内でテストを実行し、全て通ることを確認する:
+サンドボックスへのコマンド投入は**必ず `sandbox-exec.sh` 経由で行う。** `docker run` や
+`docker compose exec` を直接組み立ててはならない。イメージの解決・ビルド・コンテナの
+再利用・compose サービスの起動はすべて `sandbox-exec.sh` に集約されている。
+
+必要なら事前に `--print-plan` で解決結果（mode / container / image / compose_* 等）を
+確認できる（docker には一切触れず、exit 0 で終了する）:
 
 ```bash
-# Dockerfile.dev ベースの場合
-docker run --rm -v "$(pwd):/workspace" -w /workspace "dev-sandbox:[project]" [test-command]
-
-# docker-compose.dev.yml ベースの場合
-docker compose -f docker-compose.dev.yml exec app [test-command]
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+テストは `--epic` を渡して実行する（Epic 単位でコンテナ・キャッシュが共有される）:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" '[test-command]'
+```
+
+全て通ることを確認する。
 
 ## 重要度の基準
 

--- a/codex-agents/evaluator.toml
+++ b/codex-agents/evaluator.toml
@@ -385,16 +385,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/codex-agents/generator.toml
+++ b/codex-agents/generator.toml
@@ -89,6 +89,25 @@ gh issue view "$TASK_NUMBER"
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" '[test-command]'
 ```
 
+#### `--epic` を必ず渡す
+
+呼び出し時は**必ず `--epic` を渡す**（または `DEV_WORKFLOW_EPIC` 環境変数を設定して尊重する）。
+分離の単位は epic であり、`--epic` を渡し忘れると自分の worktree 専用の別コンテナが
+新たに立ち上がってしまい、epic 内の他タスクと同じコンテナ・同じキャッシュを共有できない。
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic3 '[test-command]'
+```
+
+#### シェルスクリプトを新規生成したら `.gitattributes` を確認する
+
+Windows（`core.autocrlf=true`）で生成した `.sh` は CRLF になり、サンドボックス
+（Linuxコンテナ）内で `syntax error near unexpected token $'{\r'` のように、
+原因が分かりにくい形で失敗する。`.sh` を新規生成したら対象プロジェクトの
+`.gitattributes` に `*.sh text eol=lf` があるか確認し、無ければ追加すること。
+`check-prerequisites.sh` がセッション開始時にこの条件を検出して警告するが、
+警告はブロックしないため、生成側でも確認を徹底する。
+
 #### コマンドは1回にまとめる
 
 **ビルド・vet・テストを別々に呼び出してはならない。** サンドボックスはソースツリーを

--- a/codex-agents/generator.toml
+++ b/codex-agents/generator.toml
@@ -374,16 +374,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/codex-agents/planner.toml
+++ b/codex-agents/planner.toml
@@ -275,16 +275,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/core/instructions.md
+++ b/core/instructions.md
@@ -172,16 +172,16 @@ git commit -m "feat: セッショントークンの有効期限を検証する (
 プロジェクトルートに `Dockerfile.dev` または `docker-compose.dev.yml` を配置する。
 どちらも無い場合、コンテナ実行を前提とした自律モードは開始できない。
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動は、すべて `sandbox-exec.sh` に集約されている。
+呼び出し側がやることは `--print-plan` で解決結果を確認し、コマンドを投入するだけである。
+
 ```bash
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t "dev-sandbox:$(basename "$(pwd)")" .
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-else
-  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  exit 1
-fi
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+`--print-plan` が `mode=none` を返す場合、`Dockerfile.dev` も `docker-compose.dev.yml` も
+見つかっていないので、自律モードを開始せずに停止する。
 
 ## 安全ルール（例外なし）
 

--- a/core/roles/evaluator.md
+++ b/core/roles/evaluator.md
@@ -115,15 +115,24 @@ gh issue list --label task --state closed --search "[epic番号]" --json number,
 
 ### 4. テスト実行（サンドボックス内）
 
-サンドボックス内でテストを実行し、全て通ることを確認する:
+サンドボックスへのコマンド投入は**必ず `sandbox-exec.sh` 経由で行う。** `docker run` や
+`docker compose exec` を直接組み立ててはならない。イメージの解決・ビルド・コンテナの
+再利用・compose サービスの起動はすべて `sandbox-exec.sh` に集約されている。
+
+必要なら事前に `--print-plan` で解決結果（mode / container / image / compose_* 等）を
+確認できる（docker には一切触れず、exit 0 で終了する）:
 
 ```bash
-# Dockerfile.dev ベースの場合
-docker run --rm -v "$(pwd):/workspace" -w /workspace "dev-sandbox:[project]" [test-command]
-
-# docker-compose.dev.yml ベースの場合
-docker compose -f docker-compose.dev.yml exec app [test-command]
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan
 ```
+
+テストは `--epic` を渡して実行する（Epic 単位でコンテナ・キャッシュが共有される）:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" '[test-command]'
+```
+
+全て通ることを確認する。
 
 ## 重要度の基準
 

--- a/core/roles/generator.md
+++ b/core/roles/generator.md
@@ -69,6 +69,25 @@ gh issue view "$TASK_NUMBER"
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" '[test-command]'
 ```
 
+#### `--epic` を必ず渡す
+
+呼び出し時は**必ず `--epic` を渡す**（または `DEV_WORKFLOW_EPIC` 環境変数を設定して尊重する）。
+分離の単位は epic であり、`--epic` を渡し忘れると自分の worktree 専用の別コンテナが
+新たに立ち上がってしまい、epic 内の他タスクと同じコンテナ・同じキャッシュを共有できない。
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic epic3 '[test-command]'
+```
+
+#### シェルスクリプトを新規生成したら `.gitattributes` を確認する
+
+Windows（`core.autocrlf=true`）で生成した `.sh` は CRLF になり、サンドボックス
+（Linuxコンテナ）内で `syntax error near unexpected token $'{\r'` のように、
+原因が分かりにくい形で失敗する。`.sh` を新規生成したら対象プロジェクトの
+`.gitattributes` に `*.sh text eol=lf` があるか確認し、無ければ追加すること。
+`check-prerequisites.sh` がセッション開始時にこの条件を検出して警告するが、
+警告はブロックしないため、生成側でも確認を徹底する。
+
 #### コマンドは1回にまとめる
 
 **ビルド・vet・テストを別々に呼び出してはならない。** サンドボックスはソースツリーを

--- a/docs/dev-workflow-multi-vendor-guide.md
+++ b/docs/dev-workflow-multi-vendor-guide.md
@@ -960,6 +960,35 @@ Claude Code側の挙動を一切変えずに、ベンダー中立な内容を単
 - [ ] Codex 側で緩む点（`maxTurns` 相当なし、worktree分離なし、`sandbox_mode` の粒度が粗い）を明記
 - [ ] marketplace リポジトリ側のコピーとSHAを更新して配信
 
+### Phase F: サンドボックスの分離単位是正（Epic #3, 完了）
+
+v0.10.0 実運用で、期待（epic単位で分離）と実装（worktree単位で分離＋リポジトリ単位でキャッシュ共有）が
+ずれていたことが判明した（詳細は `epic/epic3/sandbox-epic-scope` のEpic本文を参照）。
+
+- [x] `tests/run-tests.sh`（Docker非依存）・`Dockerfile.dev`・`--print-plan` の骨格を追加
+- [x] バインドマウントをリポジトリルートに固定し、コンテナを epic 単位にする
+      （`dw-sandbox-<repo>[-<epic>]`。worktree数に依存しない）
+- [x] docker label（`dev-workflow.managed` 等）による後片付け（`--ls` / `--down` / `--down --all`）
+- [x] `--reset-cache` に列挙表示・running検出のガードと `--force` を追加
+      （キャッシュ volume はリポジトリ単位のまま。作用範囲が epic ではないための誤爆防止）
+- [x] イメージのビルド責務を `sandbox-exec.sh` に集約（`dev-sandbox:<repo>-<hash8>`、
+      イメージID差分によるコンテナ再作成、`--rebuild`）
+- [x] compose モードの修正（`-p` / `--project-directory` をリポジトリルート基準に固定、
+      自動 `up -d`、`container_name` / 固定ホストポートの検出警告）
+- [x] `check-readability.sh` の非対話ハング修正（引数指定時はstdinを読まない、
+      非tty時は `READABILITY_STDIN_TIMEOUT` で読み取りタイムアウト）
+- [x] `check-prerequisites.sh` にCRLF警告（非ブロッキング）を追加
+- [x] `.gitattributes` に `*.toml` / 自己参照の `eol=lf` を追加（`*.sh` は既存）。
+      既存ワーキングツリーの再正規化（`git rm --cached -r . && git reset --hard`）が必要になった
+      実障害を踏まえ、README にも明記
+- [x] 両 run スキル（`skills/run/SKILL.md` / `skills-codex/dev-workflow-run/SKILL.md`）から
+      `docker build` / `docker compose up` の直接記述を削除し `sandbox-exec.sh` に一本化
+- [x] `core/instructions.md` のサンドボックス方針を `sandbox-exec.sh` 集約に合わせて修正
+      （`agents/generator.md` / `codex-agents/generator.toml` を再生成）
+- [x] README.md のサンドボックス節を全面更新（分離単位の表、`--print-plan`、ライフサイクル操作、
+      `--reset-cache` の作用範囲、`--rebuild` の使いどころ、compose の既知の限界、CRLF注意）
+- [x] `plugin.json`（両CLI）を v0.11.0 に更新
+
 ### 調査済みの事項（初版の未確認リスト）
 
 | 項目 | 結論 | 対応 |

--- a/scripts/check-prerequisites.sh
+++ b/scripts/check-prerequisites.sh
@@ -1,6 +1,38 @@
 #!/bin/bash
 # dev-workflow plugin: 前提条件チェック
 # exit 0 = OK, exit 2 = ブロック（必須依存が不足）
+#
+# crlf_warning_message は Docker 非依存の純粋関数として切り出してあり、
+# tests/run-tests.sh から直接 source して単体テストする（Epic #3 仕様書 4.10）。
+# このファイルが source されただけの場合、以降の前提条件チェック本体は実行しない
+# （$0 と BASH_SOURCE[0] が一致するのは直接実行された場合のみ）。
+
+crlf_warning_message() {
+  # crlf_warning_message
+  # 条件: core.autocrlf が true かつ *.sh の eol 解決が lf でない。
+  # 該当すれば警告メッセージを標準出力に返し、非該当なら何も出力しない（非ブロッキング）。
+  # 判定に git check-attr を使うのは、グローバル設定を含む git 自身の解決結果を見るため。
+  local autocrlf
+  autocrlf="$(git config --get core.autocrlf 2>/dev/null)"
+  [ "$autocrlf" = "true" ] || return 0
+
+  local eol
+  eol="$(git check-attr eol -- "dev-workflow-crlf-probe.sh" 2>/dev/null | sed -n 's/^.*: eol: //p')"
+  [ "$eol" = "lf" ] && return 0
+
+  cat <<'MSG'
+[dev-workflow] 警告: core.autocrlf=true ですが、.gitattributes で *.sh の改行コードが
+lf に固定されていません。Windows で生成した .sh が CRLF のままサンドボックス
+（Linuxコンテナ）に渡ると、次のようなエラーになります（原因が分かりにくいので注意）:
+  syntax error near unexpected token $'{\r'
+対処: .gitattributes に以下の1行を追記してください:
+  *.sh text eol=lf
+MSG
+}
+
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  return 0
+fi
 
 errors=()
 
@@ -41,6 +73,15 @@ fi
 # git リポジトリチェック
 if ! git rev-parse --is-inside-work-tree &> /dev/null 2>&1; then
   errors+=("git リポジトリ内で実行してください。")
+fi
+
+# CRLF 警告（非ブロッキング。仕様書 4.10）。git リポジトリ内でのみ判定できるため、
+# 上の git リポジトリチェックが通っている場合に限って実行する。
+if git rev-parse --is-inside-work-tree &> /dev/null 2>&1; then
+  crlf_warning="$(crlf_warning_message)"
+  if [ -n "$crlf_warning" ]; then
+    echo "$crlf_warning" >&2
+  fi
 fi
 
 # エラーがあればブロック

--- a/scripts/check-prerequisites.sh
+++ b/scripts/check-prerequisites.sh
@@ -20,8 +20,7 @@ if command -v gh &> /dev/null && gh auth status &> /dev/null; then
   # gh がgitのcredential helperとして設定されているか確認
   if ! git config --global credential.helper 2>/dev/null | grep -q "gh"; then
     echo "[dev-workflow] git認証をgh CLIに委任します（ポップアップ防止）..." >&2
-    gh auth setup-git 2>/dev/null
-    if [ $? -eq 0 ]; then
+    if gh auth setup-git 2>/dev/null; then
       echo "[dev-workflow] gh auth setup-git 完了。git操作はgh CLIのトークンを使用します。" >&2
     else
       errors+=("'gh auth setup-git' に失敗しました。手動で実行してください。")

--- a/scripts/check-readability.sh
+++ b/scripts/check-readability.sh
@@ -178,8 +178,7 @@ fi
 report=""
 violated=0
 for f in "${files[@]}"; do
-  out=$(check_one "$f")
-  if [ $? -ne 0 ]; then
+  if ! out=$(check_one "$f"); then
     report="${report}${out}\n"
     violated=1
   fi

--- a/scripts/check-readability.sh
+++ b/scripts/check-readability.sh
@@ -57,19 +57,39 @@ HOOK_INPUT=""
 # フック入力は整形された（複数行の）JSONで来ることがあり、1行しか読まないと
 # 1行目に file_path が無い場合に検査対象を取りこぼして黙って素通りしてしまう
 # （可読性ガードが最優先で守るべきルールを、入力形式の差で無効化してはならない）。
-# `timeout` にstdin読み取り（`cat`）を丸ごと委譲し、既定秒数以内にEOFが来なければ
-# `timeout` が `cat` を強制終了する。強制終了時の終了コードは実装依存で、
-# GNU coreutils は 124 を返すが、Alpine(BusyBox) 等の timeout はシグナルによる
-# 終了コード（例: SIGTERMで143）を返す。両方を区別せず「非0なら入力が来なかった」
-# として扱う（正常にEOFへ到達した cat は常に 0 を返すため、これで安全に判定できる）。
+#
+# 以前は `timeout "$secs" cat` に読み取りを丸ごと委譲していたが、`timeout` は
+# GNU coreutils / BusyBox のコマンドで macOS の既定環境には存在しない
+# （`gtimeout` のみ）。command not found（status 127）を「入力が来なかった」と
+# 誤判定し、macOS では可読性ガードが常時無効化されてしまっていた。
+# 外部コマンドに依存せず、bash 組み込みの `read -t` だけで複数行を読み切る。
+#
+# 注意: `while read -t ...; do ...; done` の直後の `$?` はループの終了ステータスに
+# なり、POSIX仕様上「ループ本体が一度も実行されなければ0」になる。つまり読み取り
+# 自体がタイムアウトで失敗しても、その失敗ステータスはループの外に伝播しない。
+# そのため read の戻り値はループ内で都度チェックし、専用フラグに記録する。
+#   - status > 128: シグナルによる強制終了＝タイムアウト（bashは128+シグナル番号を返す）
+#   - status != 0 かつ <= 128: EOF。ただし改行で終端されていない最終行が
+#     `line` に残ったままループを抜けることがあるため、ループ後に明示的に追加する
+#     （末尾に改行の無い入力でも最終行を取りこぼさない）。
 read_stdin_with_timeout() {
   local timeout_secs="${READABILITY_STDIN_TIMEOUT:-5}"
-  local content
-  content="$(timeout "$timeout_secs" cat 2>/dev/null)"
-  local status=$?
-  if [ "$status" -ne 0 ]; then
+  local line="" content="" rc timed_out=0
+  while :; do
+    IFS= read -r -t "$timeout_secs" line
+    rc=$?
+    if [ "$rc" -gt 128 ]; then
+      timed_out=1
+      break
+    elif [ "$rc" -ne 0 ]; then
+      break
+    fi
+    content+="${line}"$'\n'
+  done
+  if [ "$timed_out" -eq 1 ]; then
     return 1
   fi
+  [ -n "$line" ] && content+="$line"
   printf '%s' "$content"
   return 0
 }

--- a/scripts/check-readability.sh
+++ b/scripts/check-readability.sh
@@ -53,18 +53,24 @@ MAX_LINE="${READABILITY_MAX_LINE:-5000}"
 # EOFが来ずハングする経路を作らないため）。
 HOOK_INPUT=""
 
-# 引数なし・非tty のときだけ、上限付きで stdin を読む。
-# `read -t` はタイムアウト時に exit status > 128 を返す（bashの仕様）ため、
-# それを持って「入力が来なかった」と判定する。
+# 引数なし・非tty のときだけ、上限付きで stdin を「全部」読む。
+# フック入力は整形された（複数行の）JSONで来ることがあり、1行しか読まないと
+# 1行目に file_path が無い場合に検査対象を取りこぼして黙って素通りしてしまう
+# （可読性ガードが最優先で守るべきルールを、入力形式の差で無効化してはならない）。
+# `timeout` にstdin読み取り（`cat`）を丸ごと委譲し、既定秒数以内にEOFが来なければ
+# `timeout` が `cat` を強制終了する。強制終了時の終了コードは実装依存で、
+# GNU coreutils は 124 を返すが、Alpine(BusyBox) 等の timeout はシグナルによる
+# 終了コード（例: SIGTERMで143）を返す。両方を区別せず「非0なら入力が来なかった」
+# として扱う（正常にEOFへ到達した cat は常に 0 を返すため、これで安全に判定できる）。
 read_stdin_with_timeout() {
   local timeout_secs="${READABILITY_STDIN_TIMEOUT:-5}"
-  local line=""
-  IFS= read -r -t "$timeout_secs" line
+  local content
+  content="$(timeout "$timeout_secs" cat 2>/dev/null)"
   local status=$?
-  if [ "$status" -gt 128 ]; then
+  if [ "$status" -ne 0 ]; then
     return 1
   fi
-  printf '%s' "$line"
+  printf '%s' "$content"
   return 0
 }
 

--- a/scripts/check-readability.sh
+++ b/scripts/check-readability.sh
@@ -9,7 +9,7 @@
 # 違反の通知方法はCLIごとに契約が異なるため、実行中のCLIを判定して出し分ける:
 #   - Claude Code … exit 2 + stderr にメッセージ
 #   - Codex CLI  … exit 0 + stdout に {"continue": false, ...} のJSON
-#   - pre-commit … exit 1 + stderr にメッセージ（--exit-code で明示）
+#   - pre-commit … exit 1 + stderr にメッセージ（DEV_WORKFLOW_HOOK_VENDOR=exit-code で明示）
 #
 # どちらも
 #   - PostToolUse(Write|Edit) フック → ツール結果をブロックし、理由をエージェントに差し戻す（自己修正ループ）
@@ -25,6 +25,8 @@
 #   READABILITY_GUARD=off               # ガード全体を無効化
 #   READABILITY_MAX_BASE64=2000         # 連続するbase64文字列の許容上限（文字数）
 #   READABILITY_MAX_LINE=5000           # ソース1行の許容上限（文字数。ミニファイ検出）
+#   READABILITY_STDIN_TIMEOUT=5         # 引数なし・非tty時にstdinを待つ上限秒数。
+#                                       # 超過すると警告を出してexit 0（素通り）
 #   DEV_WORKFLOW_HOOK_VENDOR=claude|codex|exit-code
 #                                       # ベンダー自動判定を上書きする（デバッグ・CI用）
 #
@@ -44,12 +46,27 @@ MAX_BASE64="${READABILITY_MAX_BASE64:-2000}"
 MAX_LINE="${READABILITY_MAX_LINE:-5000}"
 
 # ── フック入力の読み取り ─────────────────────────────────────────────
-# フック実行時は stdin に JSON が渡る。端末から手で叩いた場合は stdin が tty に
-# なるため読まない（読むとブロックしてしまう）。
+# フック実行時（引数なし）は stdin に JSON が渡る。端末から手で叩いた場合は stdin
+# が tty になるため読まない（読むとブロックしてしまう）。
+# `--git` / `--staged` / ファイル引数が1つでもある場合は検査対象が明確なので、
+# stdin は一切読まない（パイプ越し・CI・エージェントランナーからの呼び出しで
+# EOFが来ずハングする経路を作らないため）。
 HOOK_INPUT=""
-if [ ! -t 0 ]; then
-  HOOK_INPUT="$(cat 2>/dev/null || true)"
-fi
+
+# 引数なし・非tty のときだけ、上限付きで stdin を読む。
+# `read -t` はタイムアウト時に exit status > 128 を返す（bashの仕様）ため、
+# それを持って「入力が来なかった」と判定する。
+read_stdin_with_timeout() {
+  local timeout_secs="${READABILITY_STDIN_TIMEOUT:-5}"
+  local line=""
+  IFS= read -r -t "$timeout_secs" line
+  local status=$?
+  if [ "$status" -gt 128 ]; then
+    return 1
+  fi
+  printf '%s' "$line"
+  return 0
+}
 
 # ── 実行中のCLIを判定 ────────────────────────────────────────────────
 # Claude Code と Codex CLI はフックのブロック契約が異なるため、出力を出し分ける。
@@ -162,7 +179,15 @@ elif [ "$#" -gt 0 ]; then
   # 引数で指定されたファイル
   files=("$@")
 else
-  # フック入力のJSONから file_path を抽出（PostToolUse 用）
+  # 引数なし: フック入力のJSONから file_path を抽出（PostToolUse 用）。
+  # stdin が tty でなければ、上限付きで読む（既定5秒、READABILITY_STDIN_TIMEOUT で調整可）。
+  # タイムアウトした場合は「フック入力が来ないなら検査対象も無い」として素通りする。
+  if [ ! -t 0 ]; then
+    if ! HOOK_INPUT="$(read_stdin_with_timeout)"; then
+      echo "【可読性ガード】 stdin からの入力が ${READABILITY_STDIN_TIMEOUT:-5}秒 以内に得られなかったため検査をスキップします" >&2
+      exit 0
+    fi
+  fi
   raw=$(printf '%s' "$HOOK_INPUT" | grep -oE '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 \
         | sed -E 's/.*"file_path"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')
   if [ -n "$raw" ]; then

--- a/scripts/lib/compose-conflicts.sh
+++ b/scripts/lib/compose-conflicts.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# dev-workflow: compose ファイルの衝突要因検出（Docker 非依存の純粋関数）
+#
+# compose モードは `-p <PROJECT>` でプロジェクト名を分離するが、プロジェクト側の
+# compose ファイルが `container_name:` や固定ホストポート（`- "NNNN:NNNN"`）を
+# 書いていると、`-p` では解決できない衝突を起こす（Epic #3 仕様書 4.8）。
+#
+# ここではファイル内容の走査だけで判定できる部分を、docker を一切起動しない
+# 純粋関数として切り出し、tests/run-tests.sh から直接検証できるようにする。
+#
+# このファイルは sandbox-exec.sh から source される。単体では何もしない。
+
+set -u
+
+compose_conflict_warnings() {
+  # compose_conflict_warnings <compose_file>
+  # 標準出力に、検出した警告メッセージを1行1件で出す（無ければ何も出力しない）。
+  # 停止はしない（呼び出し側が stderr に warning として流す）。
+  local file="$1"
+
+  [ -f "$file" ] || return 0
+
+  if grep -Eq '^[[:space:]]*container_name[[:space:]]*:' "$file"; then
+    printf '%s\n' "compose ファイル (${file}) に container_name が設定されています。-p では解決できない衝突であり、epic の並行実行ができません。"
+  fi
+
+  # 固定ホストポート（`- "NNNN:NNNN"` 形式。IPプレフィックス付きも対象）。
+  # コンテナ側ポートのみの `- "3000"` や範囲指定のみの `- "3000-3010"`（コロン無し）は対象外。
+  if grep -Eq '^[[:space:]]*-[[:space:]]*"?([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}:)?[0-9]+:[0-9]+"?[[:space:]]*(#.*)?$' "$file"; then
+    printf '%s\n' "compose ファイル (${file}) に固定ホストポートが設定されています。-p では解決できない衝突であり、epic の並行実行ができません。"
+  fi
+}

--- a/scripts/lib/container-membership.sh
+++ b/scripts/lib/container-membership.sh
@@ -5,31 +5,57 @@
 # 引数として受け取るだけの純粋関数として切り出すことで、docker を一切起動せずに
 # tests/run-tests.sh からテストできるようにする（Epic #3 仕様書 4.5）。
 #
-# 判定基準:
-#   1. label（dev-workflow.repo）を第一とする。値があればそれが現在の repo と
-#      一致するかどうかだけで判定する。
-#   2. label が無い（旧命名の残骸）場合は、マウント元がリポジトリルート配下かで
-#      実体判定する。名前ではなく実体で判定するため、命名規則を変えても掃除が生き残る。
+# 判定基準（issue #29 で label_root を追加）:
+#   1. label（dev-workflow.repo）を第一とする。値があれば、まず現在の repo と
+#      一致するかどうかで絞り込む。不一致なら即座に対象外とする
+#      （同名 basename・別 root の混入を防ぐため、マウント元判定にはフォールバックしない）。
+#   2. label の repo が一致した場合、さらに label（dev-workflow.root）を見る。
+#      値があれば、正規化済みの HOST_ROOT と一致するときだけ対象に含める
+#      （同じ basename で別ディレクトリにクローンした場合の誤爆を防ぐ）。
+#      値が空（本 Epic 以前に起動された旧コンテナ）の場合のみ、
+#      3 のマウント元判定にフォールバックする。
+#   3. label（dev-workflow.repo）自体が無い（旧命名の残骸）場合は、マウント元が
+#      リポジトリルート配下かで実体判定する。名前ではなく実体で判定するため、
+#      命名規則を変えても掃除が生き残る。
+#
+# マウント元の比較は正規化済み（normalize_mount_source）で行う。Windows + Docker
+# Desktop では bind mount の .Source が `/run/desktop/mnt/host/c/...` という
+# Linux 側の変換済みパスで返るため、素の文字列比較では常に不一致になる（issue #25）。
 #
 # このファイルは sandbox-exec.sh から source される。単体では何もしない。
 
 set -u
 
+_CONTAINER_MEMBERSHIP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./mount-path.sh
+. "${_CONTAINER_MEMBERSHIP_DIR}/mount-path.sh"
+
 container_belongs_to_repo() {
-  # container_belongs_to_repo <label_repo> <mount_source> <host_root> <project>
+  # container_belongs_to_repo <label_repo> <label_root> <mount_source> <host_root> <project>
   # 戻り値: 0=現在のリポジトリに属する（削除対象に含める） 1=属さない
-  local label_repo="$1" mount_source="$2" host_root="$3" project="$4"
+  local label_repo="$1" label_root="$2" mount_source="$3" host_root="$4" project="$5"
 
   if [ -n "$label_repo" ]; then
-    [ "$label_repo" = "$project" ]
-    return $?
+    [ "$label_repo" = "$project" ] || return 1
+
+    if [ -n "$label_root" ]; then
+      [ "$(normalize_mount_source "$label_root")" = "$(normalize_mount_source "$host_root")" ]
+      return $?
+    fi
+    # label_root が空（本 Epic 以前に起動された旧コンテナ）の場合のみ、
+    # マウント元判定にフォールバックする。
   fi
 
-  # label なし（旧命名の残骸候補）。マウント元がリポジトリルート配下かで実体判定する。
+  # label（dev-workflow.repo）が無い、または label はあるが root label が空。
+  # マウント元がリポジトリルート配下かで実体判定する。
   [ -n "$mount_source" ] && [ -n "$host_root" ] || return 1
-  case "$mount_source" in
-    "$host_root")   return 0 ;;
-    "$host_root"/*) return 0 ;;
+
+  local norm_mount norm_host
+  norm_mount="$(normalize_mount_source "$mount_source")"
+  norm_host="$(normalize_mount_source "$host_root")"
+  case "$norm_mount" in
+    "$norm_host")   return 0 ;;
+    "$norm_host"/*) return 0 ;;
     *)              return 1 ;;
   esac
 }

--- a/scripts/lib/container-membership.sh
+++ b/scripts/lib/container-membership.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# dev-workflow: 管理コンテナの所属判定（Docker 非依存の純粋関数）
+#
+# `--down --all` の対象判定に使う。docker から取得した値（label・マウント元）を
+# 引数として受け取るだけの純粋関数として切り出すことで、docker を一切起動せずに
+# tests/run-tests.sh からテストできるようにする（Epic #3 仕様書 4.5）。
+#
+# 判定基準:
+#   1. label（dev-workflow.repo）を第一とする。値があればそれが現在の repo と
+#      一致するかどうかだけで判定する。
+#   2. label が無い（旧命名の残骸）場合は、マウント元がリポジトリルート配下かで
+#      実体判定する。名前ではなく実体で判定するため、命名規則を変えても掃除が生き残る。
+#
+# このファイルは sandbox-exec.sh から source される。単体では何もしない。
+
+set -u
+
+container_belongs_to_repo() {
+  # container_belongs_to_repo <label_repo> <mount_source> <host_root> <project>
+  # 戻り値: 0=現在のリポジトリに属する（削除対象に含める） 1=属さない
+  local label_repo="$1" mount_source="$2" host_root="$3" project="$4"
+
+  if [ -n "$label_repo" ]; then
+    [ "$label_repo" = "$project" ]
+    return $?
+  fi
+
+  # label なし（旧命名の残骸候補）。マウント元がリポジトリルート配下かで実体判定する。
+  [ -n "$mount_source" ] && [ -n "$host_root" ] || return 1
+  case "$mount_source" in
+    "$host_root")   return 0 ;;
+    "$host_root"/*) return 0 ;;
+    *)              return 1 ;;
+  esac
+}

--- a/scripts/lib/mount-path.sh
+++ b/scripts/lib/mount-path.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# dev-workflow: マウント元パスの正規化（Docker 非依存の純粋関数）
+#
+# Windows + Docker Desktop では `docker container inspect` の bind mount `.Source` が
+# `/run/desktop/mnt/host/c/Users/.../dev-workflow` という Linux 側の変換済みパスで返る。
+# 一方 sandbox-exec.sh が計算する MOUNT_SOURCE / HOST_ROOT は `pwd -W` による
+# `C:/Users/.../dev-workflow` 形式であり、素の文字列比較では常に不一致になる
+# （Epic #3 issue #25）。
+#
+# normalize_mount_source() はこの差異を吸収するため、ドライブ付きの各種表現を
+# `<DRIVE>:/...` 形式に正規化する。区切りは `/` に統一し、ドライブレターは大文字、
+# パス部分は小文字にすることで、由来の異なる同一パスを文字列比較できるようにする。
+#
+# 対応する入力形式:
+#   - /run/desktop/mnt/host/<drive>/...  （Docker Desktop の bind mount .Source）
+#   - /mnt/<drive>/...                    （WSL）
+#   - //<drive>/...                       （Git Bash 等）
+#   - <drive>:/...                        （pwd -W 等。既に正規化済みの Windows 形式）
+#
+# 上記のいずれにも一致しない入力（ドライブレターを持たない通常の Unix パス等）は、
+# 区切り文字の変換のみ行い、大小文字は変えずにそのまま返す
+# （大小文字を区別するファイルシステムでの比較を壊さないため）。
+#
+# このファイルは sandbox-exec.sh / container-membership.sh から source される。
+# 単体では何もしない。
+
+set -u
+
+normalize_mount_source() {
+  # normalize_mount_source <path>
+  local input="$1"
+  local drive rest
+
+  # バックスラッシュ区切りをスラッシュへ統一する。
+  input="${input//\\//}"
+
+  case "$input" in
+    /run/desktop/mnt/host/[A-Za-z]|/run/desktop/mnt/host/[A-Za-z]/*)
+      drive="${input#/run/desktop/mnt/host/}"
+      rest="${drive#?}"
+      drive="${drive%%/*}"
+      ;;
+    /mnt/[A-Za-z]|/mnt/[A-Za-z]/*)
+      drive="${input#/mnt/}"
+      rest="${drive#?}"
+      drive="${drive%%/*}"
+      ;;
+    //[A-Za-z]|//[A-Za-z]/*)
+      drive="${input#//}"
+      rest="${drive#?}"
+      drive="${drive%%/*}"
+      ;;
+    [A-Za-z]:|[A-Za-z]:/*)
+      drive="${input%%:*}"
+      rest="${input#*:}"
+      ;;
+    *)
+      # ドライブ形式でない通常の Unix パス。大小文字は変えずにそのまま返す。
+      printf '%s' "$input"
+      return 0
+      ;;
+  esac
+
+  drive="$(printf '%s' "$drive" | tr '[:lower:]' '[:upper:]')"
+  rest="$(printf '%s' "$rest" | tr '[:upper:]' '[:lower:]')"
+  printf '%s:%s' "$drive" "$rest"
+}

--- a/scripts/notify-slack.sh
+++ b/scripts/notify-slack.sh
@@ -83,7 +83,9 @@ if [ -n "$GIT_COMMON" ]; then
     /*|[A-Za-z]:*) ;;                       # 絶対パスならそのまま
     *) GIT_COMMON="$CWD/$GIT_COMMON" ;;     # 相対パスならcwd基準で解決
   esac
-  MAIN_ROOT="$(cd "$GIT_COMMON/.." 2>/dev/null && pwd || true)"
+  if ! MAIN_ROOT="$(cd "$GIT_COMMON/.." 2>/dev/null && pwd)"; then
+    MAIN_ROOT=""
+  fi
   [ -n "$MAIN_ROOT" ] && MARKER_ROOT="$MAIN_ROOT"
 fi
 RUN_MARKER="$MARKER_ROOT/.claude/.dev-workflow-run"

--- a/scripts/resolve-sandbox.sh
+++ b/scripts/resolve-sandbox.sh
@@ -13,12 +13,20 @@
 #   DEV_WORKFLOW_SANDBOX_MODE       dockerfile | compose | none
 #   DEV_WORKFLOW_SANDBOX_IMAGE      docker run に渡すイメージ名（compose時は空）
 #   DEV_WORKFLOW_SANDBOX_COMPOSE    使用する compose ファイル（dockerfile時は空）
-#   DEV_WORKFLOW_SANDBOX_DOCKERFILE 使用する Dockerfile（compose時は空）
+#   DEV_WORKFLOW_SANDBOX_DOCKERFILE 使用する Dockerfile（compose時・DEV_WORKFLOW_DOCKER_IMAGE指定時は空）
+#   DEV_WORKFLOW_SANDBOX_CONTEXT    docker build のビルドコンテキスト（= Dockerfile のあるディレクトリ。
+#                                   compose時・DEV_WORKFLOW_DOCKER_IMAGE指定時は空）
 #
 # 参照する環境変数（いずれも任意。未設定なら既定の探索に従う）:
-#   DEV_WORKFLOW_DOCKER_IMAGE          既存イメージを使う（ビルドしない）
+#   DEV_WORKFLOW_DOCKER_IMAGE          既存イメージを使う（ビルドしない。タグに hash は付けない）
 #   DEV_WORKFLOW_DOCKER_COMPOSE_FILE   使用する compose ファイルのパス
 #   DEV_WORKFLOW_DOCKERFILE            使用する Dockerfile のパス（既定: Dockerfile.dev）
+#
+# イメージタグの hash について（仕様書 4.7）:
+#   Dockerfile.dev からビルドする場合、タグは dev-sandbox:<repo>-<hash8> とする。
+#   hash8 は `git hash-object <Dockerfile>` の先頭8文字（git は必須依存なので追加依存が無い）。
+#   Dockerfile の内容だけを見るため、COPY 対象（go.mod 等）の変更は検知できない。
+#   その場合は sandbox-exec.sh の --rebuild で明示的に再ビルドする。
 
 set -u
 
@@ -32,8 +40,9 @@ MODE="none"
 IMAGE=""
 USE_COMPOSE=""
 USE_DOCKERFILE=""
+BUILD_CONTEXT=""
 
-# 明示指定されたイメージが最優先（ビルドを省略できる）
+# 明示指定されたイメージが最優先（ビルドを省略できる。hash は付けない）
 if [ -n "${DEV_WORKFLOW_DOCKER_IMAGE:-}" ]; then
   MODE="dockerfile"
   IMAGE="$DEV_WORKFLOW_DOCKER_IMAGE"
@@ -42,12 +51,26 @@ elif [ -f "$DOCKERFILE" ]; then
   USE_DOCKERFILE="$DOCKERFILE"
   # リポジトリ名でタグ付けする。worktree の basename（agent-xxxx 等）を使うと
   # worktree ごとに別タグとなり、既にビルド済みのイメージを取り逃す。
+  # sandbox-exec.sh の PROJECT（basename(REPO_ROOT)）と同じ解決方法にすること。
   GIT_COMMON="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
   if [ -n "$GIT_COMMON" ]; then
-    IMAGE="dev-sandbox:$(basename "$(dirname "$GIT_COMMON")")"
+    REPO="$(basename "$(dirname "$GIT_COMMON")")"
   else
-    IMAGE="dev-sandbox:$(basename "$(pwd)")"
+    REPO="$(basename "$(pwd)")"
   fi
+
+  # hash8: Dockerfile の内容から決まるタグ接尾辞。内容が同じなら worktree が
+  # 違ってもタグが変わらない。内容が変われば自動的に別タグ（≒別イメージ）になる。
+  HASH8="$(git hash-object "$DOCKERFILE" 2>/dev/null | cut -c1-8)"
+  if [ -n "$HASH8" ]; then
+    IMAGE="dev-sandbox:${REPO}-${HASH8}"
+  else
+    # git hash-object が使えない異常系のみのフォールバック（通常は到達しない）。
+    IMAGE="dev-sandbox:${REPO}"
+  fi
+
+  # ビルドコンテキストは Dockerfile のあるディレクトリ。
+  BUILD_CONTEXT="$(cd "$(dirname "$DOCKERFILE")" && { pwd -W 2>/dev/null || pwd; })"
 elif [ -f "$COMPOSE_FILE" ]; then
   MODE="compose"
   USE_COMPOSE="$COMPOSE_FILE"
@@ -57,7 +80,7 @@ if [ "$PRINT" -eq 1 ]; then
   case "$MODE" in
     dockerfile)
       if [ -n "$USE_DOCKERFILE" ]; then
-        echo "サンドボックス: ${USE_DOCKERFILE} をビルドして ${IMAGE} として使用"
+        echo "サンドボックス: ${USE_DOCKERFILE} をビルドして ${IMAGE} として使用（ビルドコンテキスト: ${BUILD_CONTEXT}）"
       else
         echo "サンドボックス: 既存イメージ ${IMAGE} を使用（DEV_WORKFLOW_DOCKER_IMAGE 指定）"
       fi
@@ -72,3 +95,4 @@ printf 'DEV_WORKFLOW_SANDBOX_MODE=%s\n'       "$MODE"
 printf 'DEV_WORKFLOW_SANDBOX_IMAGE=%s\n'      "$IMAGE"
 printf 'DEV_WORKFLOW_SANDBOX_COMPOSE=%s\n'    "$USE_COMPOSE"
 printf 'DEV_WORKFLOW_SANDBOX_DOCKERFILE=%s\n' "$USE_DOCKERFILE"
+printf 'DEV_WORKFLOW_SANDBOX_CONTEXT=%s\n'    "$BUILD_CONTEXT"

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -14,6 +14,7 @@
 #   bash scripts/sandbox-exec.sh --warm 'go build ./...'             # キャッシュを温める（失敗しても成功扱い）
 #   bash scripts/sandbox-exec.sh --down                              # 常駐コンテナを削除（キャッシュは残す）
 #   bash scripts/sandbox-exec.sh --reset-cache                       # キャッシュ volume も削除
+#   bash scripts/sandbox-exec.sh --print-plan                        # docker に触れず解決結果を表示（ドライラン）
 #
 # 終了コードは実行したコマンドのものをそのまま返す（機械的ゲートの判定に使える）。
 #
@@ -42,6 +43,7 @@ while [ $# -gt 0 ]; do
     --warm)        WARM=1; shift ;;
     --down)        ACTION="down"; shift ;;
     --reset-cache) ACTION="reset-cache"; shift ;;
+    --print-plan)  ACTION="print-plan"; shift ;;
     --)            shift; break ;;
     -*)            echo "ERROR: 未知のオプション: $1" >&2; exit 2 ;;
     *)             break ;;
@@ -86,6 +88,37 @@ cache_mount_args() {
   done
 }
 
+# --print-plan: docker に一切触れず、解決結果を key=value 形式で出力するドライラン。
+# 「コンテナ名・イメージタグ・マウント元」を外から観測できる形にし、テストで固定するために用意する。
+# この時点では現行の解決結果をそのまま出す（挙動は変えない）。
+# repo_root / rel_path / fallback / build_context / compose_* は後続タスクで追加する。
+print_plan() {
+  printf 'mode=%s\n' "${DEV_WORKFLOW_SANDBOX_MODE:-}"
+  printf 'repo=%s\n'  "$PROJECT"
+  printf 'epic=%s\n'  "$EPIC"
+
+  case "${DEV_WORKFLOW_SANDBOX_MODE:-}" in
+    dockerfile)
+      printf 'mount_source=%s\n' "$HOST_PWD"
+      printf 'mount_target=%s\n' "/workspace"
+      printf 'workdir=%s\n'      "/workspace"
+      ;;
+    *)
+      printf 'mount_source=\n'
+      printf 'mount_target=\n'
+      printf 'workdir=\n'
+      ;;
+  esac
+
+  printf 'container=%s\n' "$CONTAINER"
+  printf 'image=%s\n'     "${DEV_WORKFLOW_SANDBOX_IMAGE:-}"
+
+  local path
+  for path in $CACHE_PATHS; do
+    printf 'cache_volume=%s:%s\n' "$(cache_volume_name "$path")" "$path"
+  done
+}
+
 eval "$(bash "${SCRIPT_DIR}/resolve-sandbox.sh")"
 
 case "$ACTION" in
@@ -100,6 +133,10 @@ case "$ACTION" in
       docker volume rm "$(cache_volume_name "$path")" >/dev/null 2>&1 || true
     done
     echo "常駐コンテナとキャッシュ volume を削除しました: ${CONTAINER}"
+    exit 0
+    ;;
+  print-plan)
+    print_plan
     exit 0
     ;;
 esac

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -13,8 +13,10 @@
 #   bash scripts/sandbox-exec.sh --epic epic259 'make test'          # Epic単位でコンテナを分ける
 #   bash scripts/sandbox-exec.sh --warm 'go build ./...'             # キャッシュを温める（失敗しても成功扱い）
 #   bash scripts/sandbox-exec.sh --down                              # 現在の repo+epic のコンテナを削除（キャッシュは残す）
+#                                                                     # compose モード時は現在の project を `compose down` する
 #   bash scripts/sandbox-exec.sh --down --all                        # 現在のリポジトリに属する管理コンテナを全て削除
-#   bash scripts/sandbox-exec.sh --ls                                # 管理コンテナを一覧表示（他リポジトリ分も含む）
+#                                                                     # compose モード時は同一リポジトリの project も全て down する
+#   bash scripts/sandbox-exec.sh --ls                                # 管理コンテナを一覧表示（他リポジトリ分も含む。compose project の状態も表示）
 #   bash scripts/sandbox-exec.sh --reset-cache                       # キャッシュ volume を削除
 #                                                                     # 【作用範囲はepicではなくリポジトリ全体】
 #                                                                     # 同一リポジトリの管理コンテナが1つでも running
@@ -48,10 +50,16 @@
 #   --project-directory をリポジトリルートに固定することで、compose ファイル内の相対マウント
 #   （`.`）がどの worktree から叩いても同じツリーを指すようにする（別ツリー実行の防止）。
 #   PROJECT は worktree 名に依存しないため、agent worktree から叩いても epic worktree と
-#   同じ project になる。対象サービスが running でなければ `up -d` を試み、それでも
-#   起動しなければサービス名と DEV_WORKFLOW_COMPOSE_SERVICE を含むエラーで停止する。
+#   同じ project になる（リポジトリ外worktreeのフォールバック時は他と分離される。issue #27）。
+#   対象サービスが running でなければ `up -d` を試み、それでも起動しなければサービス名と
+#   DEV_WORKFLOW_COMPOSE_SERVICE を含むエラーで停止する。既存サービスが running でも
+#   マウント元が期待値と異なれば削除して作り直す（issue #27）。
 #   compose ファイルに container_name や固定ホストポートがあれば stderr に警告する
 #   （-p では解決できない衝突であり、停止はしない）。
+#   `--down` / `--down --all` / `--ls` は compose モードのときも対象にする（issue #28）:
+#   `--down` は現在の project を `docker compose down` で落とし、`--down --all` は
+#   同一リポジトリの `dw-<repo>` 接頭辞を持つ project をすべて列挙表示のうえ落とす。
+#   `--ls` にも compose project の状態（running/stopped）を表示する。
 
 set -u
 
@@ -174,15 +182,19 @@ PROJECT="$(basename "$REPO_ROOT")"
 SLUG="$(sanitize "$PROJECT")"
 [ -n "$EPIC" ] && SLUG="${SLUG}-$(sanitize "$EPIC")"
 
-# compose モードのプロジェクト名（仕様書 4.8）: dw-<sanitize(repo)>[-<sanitize(epic)>]。
-# フォールバック時のディレクトリ名接尾辞（下記）は含めない。worktree 名に一切依存しないため、
-# agent worktree から叩いても epic worktree と同じ project になる。
-COMPOSE_PROJECT="dw-${SLUG}"
-
-# フォールバック時は当該ディレクトリ名をコンテナ名に含め、epic 共有コンテナと混ざらないようにする。
+# フォールバック時（リポジトリ外worktree）は当該ディレクトリ名を接尾辞に含め、
+# CONTAINER と COMPOSE_PROJECT の両方を epic 共有のものと分離する（issue #27）。
+# 以前はこの接尾辞を CONTAINER にだけ反映し、COMPOSE_PROJECT は反映していなかった。
+# compose は project 名だけで既存サービスを探すため、フォールバック時に project 名が
+# 分離されていないと、別ツリー向けの running サービスへ警告なしに exec してしまっていた。
 [ "$FALLBACK" -eq 1 ] && SLUG="${SLUG}-$(sanitize "$(basename "$CUR")")"
 
 CONTAINER="dw-sandbox-${SLUG}"
+
+# compose モードのプロジェクト名（仕様書 4.8）: dw-<sanitize(repo)>[-<sanitize(epic)>][-<フォールバック接尾辞>]。
+# CONTAINER と同じ SLUG から作るため、通常時は worktree 名に依存せず agent worktree から
+# 叩いても epic worktree と同じ project になり、フォールバック時は CONTAINER と同様に分離される。
+COMPOSE_PROJECT="dw-${SLUG}"
 
 cache_volume_name() {
   printf 'dw-cache-%s-%s' \
@@ -365,14 +377,107 @@ ensure_sandbox_image() {
   fi
 }
 
+# compose モードの後片付け（issue #28）。
+# 本 Epic で compose モードは対象サービスが running でなければ up -d を自動実行するように
+# なった一方、--down / --down --all / --ls は docker label / dw-sandbox- 名の常駐コンテナしか
+# 見ておらず、compose が起動したコンテナを落とす主体がいなかった。この関数群は
+# compose_cmd（-p / --project-directory 付きの docker compose 呼び出し）を、ACTION の
+# 分岐（down/ls）と通常の exec 経路の両方から共有するために eval より前で定義する。
+compose_cmd() {
+  docker compose -p "$COMPOSE_PROJECT" --project-directory "$MOUNT_SOURCE" \
+    -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" "$@"
+}
+
+# 同一リポジトリに属する compose project 名（dw-<repo> 接頭辞）を列挙する。
+# compose が作るコンテナは com.docker.compose.project ラベルを持つため、それを一次情報にする。
+list_compose_projects_in_repo() {
+  local prefix
+  prefix="dw-$(sanitize "$PROJECT")"
+  docker ps -a --filter "label=com.docker.compose.project" \
+    --format '{{ index .Labels "com.docker.compose.project" }}' 2>/dev/null \
+    | sort -u \
+    | while IFS= read -r proj; do
+        [ -n "$proj" ] || continue
+        case "$proj" in
+          "$prefix"|"${prefix}"-*) printf '%s\n' "$proj" ;;
+        esac
+      done
+}
+
+# --ls に compose project の状態を表示する（issue #28）。他の管理コンテナ一覧
+# （list_managed）とは別出力にし、compose を使っていないプロジェクトでは何も出さない。
+list_managed_compose() {
+  local proj
+  local -a projects=()
+
+  while IFS= read -r proj; do
+    [ -n "$proj" ] && projects+=("$proj")
+  done < <(list_compose_projects_in_repo)
+
+  [ "${#projects[@]}" -gt 0 ] || return 0
+
+  echo ""
+  echo "compose project（repo=${PROJECT}）:"
+  printf '%-40s %s\n' "PROJECT" "STATUS"
+  for proj in "${projects[@]}"; do
+    if docker ps --filter "label=com.docker.compose.project=${proj}" --format '{{.ID}}' 2>/dev/null | grep -q .; then
+      printf '%-40s %s\n' "$proj" "running"
+    else
+      printf '%-40s %s\n' "$proj" "stopped"
+    fi
+  done
+}
+
+# --down --all の compose 版。同一リポジトリに属する project をすべて列挙表示したうえで
+# 1つずつ down する（issue #28）。dockerfile モードの残骸（dw-sandbox-*）は down_all が
+# 別途処理するため、ここでは compose project だけを対象にする。
+down_all_compose() {
+  local proj
+  local -a targets=()
+
+  while IFS= read -r proj; do
+    [ -n "$proj" ] && targets+=("$proj")
+  done < <(list_compose_projects_in_repo)
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    echo "削除対象の compose project はありません（repo=${PROJECT}）"
+    return 0
+  fi
+
+  echo "削除対象の compose project（repo=${PROJECT}）:"
+  for proj in "${targets[@]}"; do
+    echo "  - ${proj}"
+  done
+
+  for proj in "${targets[@]}"; do
+    docker compose -p "$proj" --project-directory "$MOUNT_SOURCE" \
+      -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" down >/dev/null 2>&1 || true
+  done
+
+  echo "compose project を削除しました: ${#targets[@]}件"
+}
+
 eval "$(bash "${SCRIPT_DIR}/resolve-sandbox.sh")"
 
 case "$ACTION" in
   down)
     if [ "$ALL" -eq 1 ]; then
       down_all
+      # dockerfile モードの残骸（dw-sandbox-*）とは別系統なので、compose モードで
+      # 解決された場合は compose project も併せて掃除する（issue #28）。
+      [ "$DEV_WORKFLOW_SANDBOX_MODE" = "compose" ] && down_all_compose
       exit 0
     fi
+
+    if [ "$DEV_WORKFLOW_SANDBOX_MODE" = "compose" ]; then
+      # compose が作るコンテナは dw-sandbox-<slug> という名前を持たないため、
+      # docker rm ではなく docker compose down で project ごと落とす（issue #28）。
+      echo "削除対象の compose project: ${COMPOSE_PROJECT}"
+      compose_cmd down >/dev/null 2>&1 || true
+      echo "compose project を削除しました: ${COMPOSE_PROJECT}（キャッシュ volume は残しています）"
+      exit 0
+    fi
+
     echo "削除対象のコンテナ: ${CONTAINER}"
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
     echo "常駐コンテナを削除しました: ${CONTAINER}（キャッシュ volume は残しています）"
@@ -380,6 +485,8 @@ case "$ACTION" in
     ;;
   ls)
     list_managed
+    # compose モードで解決された場合のみ compose project の状態も表示する（issue #28）。
+    [ "$DEV_WORKFLOW_SANDBOX_MODE" = "compose" ] && list_managed_compose
     exit 0
     ;;
   reset-cache)
@@ -438,10 +545,7 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
     # --project-directory は MOUNT_SOURCE（通常 HOST_ROOT。リポジトリ外 worktree の
     # フォールバック時のみ CUR）を指定する。これにより compose ファイル内の相対マウント
     # （`.`）がどの worktree から叩いても同じツリーを指す（別ツリー実行の防止）。
-    compose_cmd() {
-      docker compose -p "$COMPOSE_PROJECT" --project-directory "$MOUNT_SOURCE" \
-        -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" "$@"
-    }
+    # compose_cmd 自体は eval より前で定義済み（--down / --ls とも共有するため）。
 
     # 衝突要因の検出（container_name / 固定ホストポート）。Docker 非依存の関数で判定し、
     # 見つかっても警告のみで停止しない（-p では解決できない衝突であり、
@@ -450,12 +554,32 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
       [ -n "$warning_line" ] && echo "WARNING: ${warning_line}" >&2
     done < <(compose_conflict_warnings "$DEV_WORKFLOW_SANDBOX_COMPOSE")
 
+    compose_service_container_id() {
+      compose_cmd ps -q "$COMPOSE_SERVICE" 2>/dev/null || true
+    }
+
     compose_service_running() {
       local cid
-      cid="$(compose_cmd ps -q "$COMPOSE_SERVICE" 2>/dev/null || true)"
+      cid="$(compose_service_container_id)"
       [ -n "$cid" ] || return 1
       [ "$(docker container inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)" = "true" ]
     }
+
+    # 既存サービスの再利用前にマウント元を検証する（issue #27）。
+    # フォールバック時の compose_project 分離（本コミットで修正済み）が主たる対策だが、
+    # 手動で project 名を揃えて叩かれた場合等に備え、running なサービスが見つかっても
+    # マウント元が期待値（MOUNT_SOURCE）と異なれば、dockerfile モードと同様に削除して
+    # 作り直す。正規化済み比較は normalize_mount_source を再利用する（issue #25）。
+    COMPOSE_MOUNT_TEMPLATE='{{ range .Mounts }}{{ if eq .Destination "'"$COMPOSE_WORKDIR_BASE"'" }}{{ .Source }}{{ end }}{{ end }}'
+
+    if compose_service_running; then
+      EXISTING_COMPOSE_CID="$(compose_service_container_id)"
+      EXISTING_COMPOSE_MOUNT="$(docker container inspect -f "$COMPOSE_MOUNT_TEMPLATE" "$EXISTING_COMPOSE_CID" 2>/dev/null || true)"
+      if [ -n "$EXISTING_COMPOSE_MOUNT" ] && [ "$(normalize_mount_source "$EXISTING_COMPOSE_MOUNT")" != "$(normalize_mount_source "$MOUNT_SOURCE")" ]; then
+        echo "WARNING: compose サービス '${COMPOSE_SERVICE}'（project=${COMPOSE_PROJECT}）の既存コンテナのマウント元 (${EXISTING_COMPOSE_MOUNT}) が期待値 (${MOUNT_SOURCE}) と異なるため削除して作り直します（別ツリー実行の防止）" >&2
+        docker rm -f "$EXISTING_COMPOSE_CID" >/dev/null 2>&1 || true
+      fi
+    fi
 
     # サービスの起動確認と自動 up（仕様書 4.8 の 3）。
     if ! compose_service_running; then

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -40,7 +40,18 @@
 # 参照する環境変数:
 #   DEV_WORKFLOW_CACHE_PATHS      volume 化するコンテナ内パス（スペース区切り）。既定は下記 DEFAULT_CACHE_PATHS
 #   DEV_WORKFLOW_COMPOSE_SERVICE  compose モードで exec するサービス名（既定: app）
+#   DEV_WORKFLOW_COMPOSE_WORKDIR  compose モードでのコンテナ内マウント先の基点（既定: /workspace）
 #   その他は resolve-sandbox.sh を参照
+#
+# compose モードについて（仕様書 4.8）:
+#   `docker compose -p <PROJECT> --project-directory <HOST_ROOT> -f <COMPOSE_FILE> ...` で呼ぶ。
+#   --project-directory をリポジトリルートに固定することで、compose ファイル内の相対マウント
+#   （`.`）がどの worktree から叩いても同じツリーを指すようにする（別ツリー実行の防止）。
+#   PROJECT は worktree 名に依存しないため、agent worktree から叩いても epic worktree と
+#   同じ project になる。対象サービスが running でなければ `up -d` を試み、それでも
+#   起動しなければサービス名と DEV_WORKFLOW_COMPOSE_SERVICE を含むエラーで停止する。
+#   compose ファイルに container_name や固定ホストポートがあれば stderr に警告する
+#   （-p では解決できない衝突であり、停止はしない）。
 
 set -u
 
@@ -48,6 +59,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=lib/container-membership.sh
 . "${SCRIPT_DIR}/lib/container-membership.sh"
+# shellcheck source=lib/compose-conflicts.sh
+. "${SCRIPT_DIR}/lib/compose-conflicts.sh"
 
 # 言語ごとのキャッシュ置き場。存在しないパスを指定しても docker が作るだけなので無害。
 # イメージが root 以外のユーザーで動く場合は DEV_WORKFLOW_CACHE_PATHS で上書きする。
@@ -131,6 +144,13 @@ fi
 WORKDIR="/workspace"
 [ -n "$REL" ] && WORKDIR="/workspace/${REL}"
 
+# compose モードのコンテナ内 workdir（仕様書 4.8）。
+# DEV_WORKFLOW_COMPOSE_WORKDIR（既定 /workspace）+ REL。compose ファイル側が
+# `.:/workspace` をマウントする前提とし、異なる場合は環境変数で上書きする。
+COMPOSE_WORKDIR_BASE="${DEV_WORKFLOW_COMPOSE_WORKDIR:-/workspace}"
+COMPOSE_WORKDIR="$COMPOSE_WORKDIR_BASE"
+[ -n "$REL" ] && COMPOSE_WORKDIR="${COMPOSE_WORKDIR_BASE}/${REL}"
+
 # キャッシュはリポジトリ単位で共有する。worktree の basename（agent-xxxx 等）を使うと
 # generator の isolation worktree ごとに別キャッシュになり、キャッシュが効かなくなる。
 # フォールバック時も PROJECT はリポジトリルート基準のまま変えない（キャッシュは常にリポジトリ単位）。
@@ -143,6 +163,11 @@ PROJECT="$(basename "$REPO_ROOT")"
 
 SLUG="$(sanitize "$PROJECT")"
 [ -n "$EPIC" ] && SLUG="${SLUG}-$(sanitize "$EPIC")"
+
+# compose モードのプロジェクト名（仕様書 4.8）: dw-<sanitize(repo)>[-<sanitize(epic)>]。
+# フォールバック時のディレクトリ名接尾辞（下記）は含めない。worktree 名に一切依存しないため、
+# agent worktree から叩いても epic worktree と同じ project になる。
+COMPOSE_PROJECT="dw-${SLUG}"
 
 # フォールバック時は当該ディレクトリ名をコンテナ名に含め、epic 共有コンテナと混ざらないようにする。
 [ "$FALLBACK" -eq 1 ] && SLUG="${SLUG}-$(sanitize "$(basename "$CUR")")"
@@ -164,7 +189,6 @@ cache_mount_args() {
 
 # --print-plan: docker に一切触れず、解決結果を key=value 形式で出力するドライラン。
 # 「コンテナ名・イメージタグ・マウント元」を外から観測できる形にし、テストで固定するために用意する。
-# compose_* は後続タスク（#9）で追加する。
 print_plan() {
   printf 'mode=%s\n' "${DEV_WORKFLOW_SANDBOX_MODE:-}"
   printf 'repo=%s\n'  "$PROJECT"
@@ -179,6 +203,11 @@ print_plan() {
       printf 'mount_target=%s\n' "/workspace"
       printf 'workdir=%s\n'      "$WORKDIR"
       ;;
+    compose)
+      printf 'mount_source=\n'
+      printf 'mount_target=\n'
+      printf 'workdir=%s\n' "$COMPOSE_WORKDIR"
+      ;;
     *)
       printf 'mount_source=\n'
       printf 'mount_target=\n'
@@ -190,6 +219,9 @@ print_plan() {
   printf 'image=%s\n'     "${DEV_WORKFLOW_SANDBOX_IMAGE:-}"
   printf 'dockerfile=%s\n'     "${DEV_WORKFLOW_SANDBOX_DOCKERFILE:-}"
   printf 'build_context=%s\n' "${DEV_WORKFLOW_SANDBOX_CONTEXT:-}"
+  printf 'compose_file=%s\n'    "${DEV_WORKFLOW_SANDBOX_COMPOSE:-}"
+  printf 'compose_project=%s\n' "$COMPOSE_PROJECT"
+  printf 'compose_service=%s\n' "$COMPOSE_SERVICE"
 
   local path
   for path in $CACHE_PATHS; do
@@ -389,8 +421,51 @@ run_and_report() {
 
 case "$DEV_WORKFLOW_SANDBOX_MODE" in
   compose)
-    run_and_report docker compose -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" \
-      exec -T "$COMPOSE_SERVICE" sh -c "$CMD"
+    # プロジェクト名とマウント基準の固定（仕様書 4.8）。
+    # --project-directory は MOUNT_SOURCE（通常 HOST_ROOT。リポジトリ外 worktree の
+    # フォールバック時のみ CUR）を指定する。これにより compose ファイル内の相対マウント
+    # （`.`）がどの worktree から叩いても同じツリーを指す（別ツリー実行の防止）。
+    compose_cmd() {
+      docker compose -p "$COMPOSE_PROJECT" --project-directory "$MOUNT_SOURCE" \
+        -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" "$@"
+    }
+
+    # 衝突要因の検出（container_name / 固定ホストポート）。Docker 非依存の関数で判定し、
+    # 見つかっても警告のみで停止しない（-p では解決できない衝突であり、
+    # epic の並行実行ができない旨を伝える）。
+    while IFS= read -r warning_line; do
+      [ -n "$warning_line" ] && echo "WARNING: ${warning_line}" >&2
+    done < <(compose_conflict_warnings "$DEV_WORKFLOW_SANDBOX_COMPOSE")
+
+    compose_service_running() {
+      local cid
+      cid="$(compose_cmd ps -q "$COMPOSE_SERVICE" 2>/dev/null || true)"
+      [ -n "$cid" ] || return 1
+      [ "$(docker container inspect -f '{{.State.Running}}' "$cid" 2>/dev/null || true)" = "true" ]
+    }
+
+    # サービスの起動確認と自動 up（仕様書 4.8 の 3）。
+    if ! compose_service_running; then
+      echo "compose サービス '${COMPOSE_SERVICE}' が running ではないため起動します: docker compose up -d ${COMPOSE_SERVICE}" >&2
+      compose_cmd up -d "$COMPOSE_SERVICE" >/dev/null 2>&1 || true
+    fi
+
+    if ! compose_service_running; then
+      echo "ERROR: compose サービス '${COMPOSE_SERVICE}' を起動できませんでした。" >&2
+      echo "       compose ファイル (${DEV_WORKFLOW_SANDBOX_COMPOSE}) にサービス '${COMPOSE_SERVICE}' が定義され、常駐する設定になっているか確認してください。" >&2
+      echo "       既定のサービス名は 'app' です。異なる名前を使う場合は環境変数 DEV_WORKFLOW_COMPOSE_SERVICE で指定してください。" >&2
+      exit 1
+    fi
+
+    # exec 前に workdir の存在を確認する（仕様書 4.8 の workdir 解決）。
+    if ! compose_cmd exec -T "$COMPOSE_SERVICE" test -d "$COMPOSE_WORKDIR" >/dev/null 2>&1; then
+      echo "ERROR: コンテナ内に作業ディレクトリ (${COMPOSE_WORKDIR}) が見つかりません。" >&2
+      echo "       compose ファイルのマウント先と DEV_WORKFLOW_COMPOSE_WORKDIR（既定 /workspace）が食い違っている可能性があります。" >&2
+      echo "       compose ファイル側でリポジトリルートを ${COMPOSE_WORKDIR_BASE} にマウントするか、DEV_WORKFLOW_COMPOSE_WORKDIR を実際のマウント先に合わせてください。" >&2
+      exit 1
+    fi
+
+    run_and_report compose_cmd exec -T -w "$COMPOSE_WORKDIR" "$COMPOSE_SERVICE" sh -c "$CMD"
     exit $?
     ;;
 

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -12,7 +12,9 @@
 #   bash scripts/sandbox-exec.sh 'go build ./... && go test ./...'   # 実行（複数コマンドは1回にまとめる）
 #   bash scripts/sandbox-exec.sh --epic epic259 'make test'          # Epic単位でコンテナを分ける
 #   bash scripts/sandbox-exec.sh --warm 'go build ./...'             # キャッシュを温める（失敗しても成功扱い）
-#   bash scripts/sandbox-exec.sh --down                              # 常駐コンテナを削除（キャッシュは残す）
+#   bash scripts/sandbox-exec.sh --down                              # 現在の repo+epic のコンテナを削除（キャッシュは残す）
+#   bash scripts/sandbox-exec.sh --down --all                        # 現在のリポジトリに属する管理コンテナを全て削除
+#   bash scripts/sandbox-exec.sh --ls                                # 管理コンテナを一覧表示（他リポジトリ分も含む）
 #   bash scripts/sandbox-exec.sh --reset-cache                       # キャッシュ volume も削除
 #   bash scripts/sandbox-exec.sh --print-plan                        # docker に触れず解決結果を表示（ドライラン）
 #
@@ -27,6 +29,9 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=lib/container-membership.sh
+. "${SCRIPT_DIR}/lib/container-membership.sh"
+
 # 言語ごとのキャッシュ置き場。存在しないパスを指定しても docker が作るだけなので無害。
 # イメージが root 以外のユーザーで動く場合は DEV_WORKFLOW_CACHE_PATHS で上書きする。
 DEFAULT_CACHE_PATHS="/root/.cache/go-build /go/pkg/mod /root/.npm /root/.cache/yarn /root/.cargo/registry /root/.cache/pip"
@@ -35,6 +40,7 @@ COMPOSE_SERVICE="${DEV_WORKFLOW_COMPOSE_SERVICE:-app}"
 
 EPIC=""
 WARM=0
+ALL=0
 ACTION="exec"
 
 while [ $# -gt 0 ]; do
@@ -42,6 +48,8 @@ while [ $# -gt 0 ]; do
     --epic)        EPIC="${2:-}"; shift 2 ;;
     --warm)        WARM=1; shift ;;
     --down)        ACTION="down"; shift ;;
+    --all)         ALL=1; shift ;;
+    --ls)          ACTION="ls"; shift ;;
     --reset-cache) ACTION="reset-cache"; shift ;;
     --print-plan)  ACTION="print-plan"; shift ;;
     --)            shift; break ;;
@@ -166,12 +174,91 @@ print_plan() {
   done
 }
 
+# 管理コンテナの列挙・後片付け（仕様書 4.2 / 4.5）。
+# 「管理コンテナ」の候補は次の2系統の和集合とする（重複は名前で除去する）:
+#   1. label（dev-workflow.managed=1）を持つコンテナ
+#   2. label を持たない旧命名の残骸（名前が dw-sandbox- で始まるコンテナ）
+# 1 は他リポジトリ・他 epic のものも含む。2 は所属判定（container_belongs_to_repo）で
+# マウント元を見て絞り込む必要があるため、ここでは名前だけを集める。
+container_field() {
+  # container_field <container名> <goテンプレート>
+  docker container inspect -f "$2" "$1" 2>/dev/null || true
+}
+
+list_managed_candidate_names() {
+  {
+    docker ps -a --filter "label=dev-workflow.managed=1" --format '{{.Names}}' 2>/dev/null
+    docker ps -a --filter "name=dw-sandbox-" --format '{{.Names}}' 2>/dev/null
+  } | sort -u
+}
+
+MOUNT_SOURCE_TEMPLATE='{{ range .Mounts }}{{ if eq .Destination "/workspace" }}{{ .Source }}{{ end }}{{ end }}'
+
+list_managed() {
+  local name label_repo label_epic image status created found=0
+
+  printf '%-40s %-20s %-15s %-30s %-12s %s\n' "NAME" "REPO" "EPIC" "IMAGE" "STATUS" "CREATED"
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    found=1
+    label_repo="$(container_field "$name" '{{ index .Config.Labels "dev-workflow.repo" }}')"
+    label_epic="$(container_field "$name" '{{ index .Config.Labels "dev-workflow.epic" }}')"
+    image="$(container_field "$name" '{{ .Config.Image }}')"
+    status="$(container_field "$name" '{{ .State.Status }}')"
+    created="$(container_field "$name" '{{ .Created }}')"
+    printf '%-40s %-20s %-15s %-30s %-12s %s\n' \
+      "$name" "${label_repo:--}" "${label_epic:--}" "${image:--}" "${status:--}" "${created:--}"
+  done < <(list_managed_candidate_names)
+
+  [ "$found" -eq 1 ] || echo "管理コンテナはありません"
+}
+
+down_all() {
+  local name label_repo mount_source
+  local -a targets=()
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    label_repo="$(container_field "$name" '{{ index .Config.Labels "dev-workflow.repo" }}')"
+    mount_source="$(container_field "$name" "$MOUNT_SOURCE_TEMPLATE")"
+    if container_belongs_to_repo "$label_repo" "$mount_source" "$HOST_ROOT" "$PROJECT"; then
+      targets+=("$name")
+    fi
+  done < <(list_managed_candidate_names)
+
+  if [ "${#targets[@]}" -eq 0 ]; then
+    echo "削除対象の管理コンテナはありません（repo=${PROJECT}）"
+    return 0
+  fi
+
+  echo "削除対象のコンテナ（repo=${PROJECT}）:"
+  for name in "${targets[@]}"; do
+    echo "  - ${name}"
+  done
+
+  for name in "${targets[@]}"; do
+    docker rm -f "$name" >/dev/null 2>&1 || true
+  done
+
+  echo "削除しました: ${#targets[@]}件"
+}
+
 eval "$(bash "${SCRIPT_DIR}/resolve-sandbox.sh")"
 
 case "$ACTION" in
   down)
+    if [ "$ALL" -eq 1 ]; then
+      down_all
+      exit 0
+    fi
+    echo "削除対象のコンテナ: ${CONTAINER}"
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
     echo "常駐コンテナを削除しました: ${CONTAINER}（キャッシュ volume は残しています）"
+    exit 0
+    ;;
+  ls)
+    list_managed
     exit 0
     ;;
   reset-cache)
@@ -221,9 +308,7 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
     # 実行してしまう経路になるため削除して作り直す（仕様書 4.3 の 2）。
     # イメージID差分による再作成は #8 で追加する。
     if docker container inspect "$CONTAINER" >/dev/null 2>&1; then
-      EXISTING_MOUNT="$(docker container inspect \
-        -f '{{ range .Mounts }}{{ if eq .Destination "/workspace" }}{{ .Source }}{{ end }}{{ end }}' \
-        "$CONTAINER" 2>/dev/null || true)"
+      EXISTING_MOUNT="$(container_field "$CONTAINER" "$MOUNT_SOURCE_TEMPLATE")"
       if [ -n "$EXISTING_MOUNT" ] && [ "$EXISTING_MOUNT" != "$MOUNT_SOURCE" ]; then
         echo "WARNING: 既存コンテナ ${CONTAINER} のマウント元 (${EXISTING_MOUNT}) が期待値 (${MOUNT_SOURCE}) と異なるため削除して作り直します（別ツリー実行の防止）" >&2
         docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
@@ -234,6 +319,10 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
     if ! docker container inspect "$CONTAINER" >/dev/null 2>&1; then
       # shellcheck disable=SC2046  # マウント引数は意図的に単語分割する
       docker run -d --name "$CONTAINER" \
+        --label "dev-workflow.managed=1" \
+        --label "dev-workflow.repo=${PROJECT}" \
+        --label "dev-workflow.epic=${EPIC}" \
+        --label "dev-workflow.root=${HOST_ROOT}" \
         -v "${MOUNT_SOURCE}:/workspace" $(cache_mount_args) \
         -w /workspace "$DEV_WORKFLOW_SANDBOX_IMAGE" sleep infinity >/dev/null || {
           echo "ERROR: サンドボックスコンテナを起動できません: ${CONTAINER}" >&2

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -15,7 +15,11 @@
 #   bash scripts/sandbox-exec.sh --down                              # 現在の repo+epic のコンテナを削除（キャッシュは残す）
 #   bash scripts/sandbox-exec.sh --down --all                        # 現在のリポジトリに属する管理コンテナを全て削除
 #   bash scripts/sandbox-exec.sh --ls                                # 管理コンテナを一覧表示（他リポジトリ分も含む）
-#   bash scripts/sandbox-exec.sh --reset-cache                       # キャッシュ volume も削除
+#   bash scripts/sandbox-exec.sh --reset-cache                       # キャッシュ volume を削除
+#                                                                     # 【作用範囲はepicではなくリポジトリ全体】
+#                                                                     # 同一リポジトリの管理コンテナが1つでも running
+#                                                                     # なら中断し、--force の指定を促す
+#   bash scripts/sandbox-exec.sh --reset-cache --force                # running でも強制的に削除する
 #   bash scripts/sandbox-exec.sh --print-plan                        # docker に触れず解決結果を表示（ドライラン）
 #
 # 終了コードは実行したコマンドのものをそのまま返す（機械的ゲートの判定に使える）。
@@ -41,6 +45,7 @@ COMPOSE_SERVICE="${DEV_WORKFLOW_COMPOSE_SERVICE:-app}"
 EPIC=""
 WARM=0
 ALL=0
+FORCE=0
 ACTION="exec"
 
 while [ $# -gt 0 ]; do
@@ -51,6 +56,7 @@ while [ $# -gt 0 ]; do
     --all)         ALL=1; shift ;;
     --ls)          ACTION="ls"; shift ;;
     --reset-cache) ACTION="reset-cache"; shift ;;
+    --force)       FORCE=1; shift ;;
     --print-plan)  ACTION="print-plan"; shift ;;
     --)            shift; break ;;
     -*)            echo "ERROR: 未知のオプション: $1" >&2; exit 2 ;;
@@ -244,6 +250,24 @@ down_all() {
   echo "削除しました: ${#targets[@]}件"
 }
 
+# --reset-cache のガード（仕様書 4.6）。
+# キャッシュ volume はリポジトリ単位で共有する（epic 単位にはしない）ため、
+# running 判定は現在の epic だけでなく、同一リポジトリに属する管理コンテナ全体
+# （他 epic のものも含む）を対象にする。所属判定は down_all と同じ
+# container_belongs_to_repo を再利用し、重複実装しない。
+list_running_containers_in_repo() {
+  local name label_repo mount_source running
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    label_repo="$(container_field "$name" '{{ index .Config.Labels "dev-workflow.repo" }}')"
+    mount_source="$(container_field "$name" "$MOUNT_SOURCE_TEMPLATE")"
+    container_belongs_to_repo "$label_repo" "$mount_source" "$HOST_ROOT" "$PROJECT" || continue
+    running="$(container_field "$name" '{{.State.Running}}')"
+    [ "$running" = "true" ] && printf '%s\n' "$name"
+  done < <(list_managed_candidate_names)
+}
+
 eval "$(bash "${SCRIPT_DIR}/resolve-sandbox.sh")"
 
 case "$ACTION" in
@@ -262,6 +286,27 @@ case "$ACTION" in
     exit 0
     ;;
   reset-cache)
+    # 1. 削除対象の volume 名をすべて列挙して表示する（成否によらず必ず表示する）。
+    echo "削除対象のキャッシュ volume（repo=${PROJECT}。作用範囲はepicではなくリポジトリ全体です）:"
+    for path in $CACHE_PATHS; do
+      echo "  - $(cache_volume_name "$path")"
+    done
+
+    # 2. 同一リポジトリの管理コンテナが1つでも running なら中断し、--force を促す。
+    #    --force 指定時のみ running でも実行する。
+    if [ "$FORCE" -ne 1 ]; then
+      RUNNING_NAMES="$(list_running_containers_in_repo)"
+      if [ -n "$RUNNING_NAMES" ]; then
+        echo "ERROR: 同一リポジトリの管理コンテナが running のため中断しました。--reset-cache の作用範囲はepicではなくリポジトリ全体のため、他 epic の実行中コンテナのキャッシュも壊れます:" >&2
+        printf '%s\n' "$RUNNING_NAMES" | while IFS= read -r name; do
+          echo "  - ${name}" >&2
+        done
+        echo "続行するには --force を指定してください: bash scripts/sandbox-exec.sh --reset-cache --force" >&2
+        exit 1
+      fi
+    fi
+
+    # 5. 削除するのは volume と当該（現在の repo+epic の）コンテナのみで、他 epic のコンテナは削除しない。
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
     for path in $CACHE_PATHS; do
       docker volume rm "$(cache_volume_name "$path")" >/dev/null 2>&1 || true

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -58,7 +58,12 @@
 #   （-p では解決できない衝突であり、停止はしない）。
 #   `--down` / `--down --all` / `--ls` は compose モードのときも対象にする（issue #28）:
 #   `--down` は現在の project を `docker compose down` で落とし、`--down --all` は
-#   同一リポジトリの `dw-<repo>` 接頭辞を持つ project をすべて列挙表示のうえ落とす。
+#   同一リポジトリに属する project をすべて列挙表示のうえ落とす。「同一リポジトリに属する」の
+#   判定は project 名の接頭辞一致ではなく、`com.docker.compose.project.working_dir` label
+#   （= `--project-directory` に渡した値）を正規化して HOST_ROOT と一致する（配下を含む）かで行う
+#   （issue #33。接頭辞一致だけでは他リポジトリの project を巻き込む）。
+#   リポジトリ外 worktree のフォールバック実行では working_dir が HOST_ROOT 外になるため、
+#   そこで起動した project は `--down --all` の対象に含まれない。
 #   `--ls` にも compose project の状態（running/stopped）を表示する。
 
 set -u
@@ -388,20 +393,44 @@ compose_cmd() {
     -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" "$@"
 }
 
-# 同一リポジトリに属する compose project 名（dw-<repo> 接頭辞）を列挙する。
+# 同一リポジトリに属する compose project 名を列挙する。
 # compose が作るコンテナは com.docker.compose.project ラベルを持つため、それを一次情報にする。
+#
+# `docker ps` のフォーマットコンテキストでは `.Labels` は map ではなく `k=v,k=v` 形式の
+# 文字列であり、`{{ index .Labels "..." }}` は「slice/array を string で index できない」で
+# 必ず失敗する（`.Labels` が map になるのは `docker inspect` 系のみ）。`docker ps` では
+# `{{.Label "..."}}` を使う必要がある（issue #32）。
+# 失敗を `2>/dev/null` で握り潰すと、この手のテンプレート誤用が常に「対象0件」として
+# 沈黙してしまう（実害: --down --all が何も落とさないのに成功したかのように見える）ため、
+# 終了コードが非0なら stderr に警告を出す。
+#
+# 「同一リポジトリに属する」の判定は project 名の接頭辞一致ではなく、compose が付与する
+# com.docker.compose.project.working_dir ラベル（= --project-directory に渡した値）を
+# normalize_mount_source() で正規化し、HOST_ROOT と一致する（配下を含む）かで行う
+# （issue #33）。接頭辞一致だけだと次のような混入が起こる:
+#   - リポジトリ名が他リポジトリ名の接頭辞になっている場合
+#   - 同じ basename を別ディレクトリにクローンしている場合
+# dockerfile 経路は #29 で dev-workflow.root label による厳密判定を入れているので、
+# compose 経路もここで同水準の判定にそろえる。
 list_compose_projects_in_repo() {
-  local prefix
-  prefix="dw-$(sanitize "$PROJECT")"
-  docker ps -a --filter "label=com.docker.compose.project" \
-    --format '{{ index .Labels "com.docker.compose.project" }}' 2>/dev/null \
-    | sort -u \
-    | while IFS= read -r proj; do
-        [ -n "$proj" ] || continue
-        case "$proj" in
-          "$prefix"|"${prefix}"-*) printf '%s\n' "$proj" ;;
-        esac
-      done
+  local raw rc norm_host proj wd norm_wd
+  raw="$(docker ps -a --filter "label=com.docker.compose.project" \
+    --format '{{.Label "com.docker.compose.project"}}|{{.Label "com.docker.compose.project.working_dir"}}' 2>&1)"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "WARNING: docker ps による compose project の列挙に失敗しました（終了コード${rc}）: ${raw}" >&2
+    return 0
+  fi
+
+  norm_host="$(normalize_mount_source "$HOST_ROOT")"
+
+  printf '%s\n' "$raw" | sort -u | while IFS='|' read -r proj wd; do
+    [ -n "$proj" ] || continue
+    norm_wd="$(normalize_mount_source "$wd")"
+    case "$norm_wd" in
+      "$norm_host"|"$norm_host"/*) printf '%s\n' "$proj" ;;
+    esac
+  done
 }
 
 # --ls に compose project の状態を表示する（issue #28）。他の管理コンテナ一覧

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -58,20 +58,65 @@ sanitize() { printf '%s' "$1" | tr -c 'A-Za-z0-9_.-' '-'; }
 # 勝手に変換してしまう。MSYS_NO_PATHCONV=1 で変換を止めた上で、マウント元だけは
 # `pwd -W` で Windows 形式の絶対パスを明示する。Linux/macOS では pwd -W が無いので pwd を使う。
 export MSYS_NO_PATHCONV=1
-HOST_PWD="$(pwd -W 2>/dev/null || pwd)"
+CUR="$(pwd -W 2>/dev/null || pwd)"
+
+# パス解決（仕様書 4.1）。
+# バインドマウント先はリポジトリルート（worktree ではない）に固定する。これにより
+# generator の isolation worktree（agent-<id>）や epic worktree が何個増えても
+# コンテナは増えない。コンテナ内の作業ディレクトリはリポジトリルートからの相対パスで切り替える。
+GIT_COMMON="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+
+FALLBACK=0
+REL=""
+
+if [ -n "$GIT_COMMON" ]; then
+  REPO_ROOT="$(dirname "$GIT_COMMON")"
+  HOST_ROOT="$(cd "$REPO_ROOT" && { pwd -W 2>/dev/null || pwd; })"
+  case "$CUR" in
+    "$HOST_ROOT")
+      REL=""
+      ;;
+    "$HOST_ROOT"/*)
+      REL="${CUR#"$HOST_ROOT"/}"
+      ;;
+    *)
+      # 現在のディレクトリがリポジトリルート配下にない（リポジトリ外に作られた
+      # 兄弟 worktree 等）。従来どおり現在のディレクトリをマウントし、
+      # epic 共有コンテナと混ざらないようコンテナ名を分離する。
+      FALLBACK=1
+      ;;
+  esac
+else
+  # git リポジトリでない場合は従来どおり現在のディレクトリを使う。
+  REPO_ROOT="$CUR"
+  HOST_ROOT="$CUR"
+fi
+
+if [ "$FALLBACK" -eq 1 ]; then
+  MOUNT_SOURCE="$CUR"
+  echo "WARNING: 現在のディレクトリ (${CUR}) はリポジトリルート (${HOST_ROOT}) の外にあります。フォールバックとして現在のディレクトリをマウントし、コンテナは epic 共有コンテナとは分離します。" >&2
+else
+  MOUNT_SOURCE="$HOST_ROOT"
+fi
+
+WORKDIR="/workspace"
+[ -n "$REL" ] && WORKDIR="/workspace/${REL}"
 
 # キャッシュはリポジトリ単位で共有する。worktree の basename（agent-xxxx 等）を使うと
 # generator の isolation worktree ごとに別キャッシュになり、キャッシュが効かなくなる。
-GIT_COMMON="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
-if [ -n "$GIT_COMMON" ]; then
-  PROJECT="$(basename "$(dirname "$GIT_COMMON")")"
-else
-  PROJECT="$(basename "$(pwd)")"
-fi
+# フォールバック時も PROJECT はリポジトリルート基準のまま変えない（キャッシュは常にリポジトリ単位）。
+PROJECT="$(basename "$REPO_ROOT")"
 
-# コンテナはバインドマウント先が異なるため worktree 単位で分ける。
-SLUG="$(sanitize "$(basename "$(pwd)")")"
+# コンテナ名（仕様書 4.2）。repo は REPO_ROOT の basename（worktree の basename は使わない）。
+# --epic 未指定時は環境変数 DEV_WORKFLOW_EPIC を参照する
+# （generator が --epic を渡し忘れても同じコンテナに載るようにするため）。
+[ -z "$EPIC" ] && EPIC="${DEV_WORKFLOW_EPIC:-}"
+
+SLUG="$(sanitize "$PROJECT")"
 [ -n "$EPIC" ] && SLUG="${SLUG}-$(sanitize "$EPIC")"
+
+# フォールバック時は当該ディレクトリ名をコンテナ名に含め、epic 共有コンテナと混ざらないようにする。
+[ "$FALLBACK" -eq 1 ] && SLUG="${SLUG}-$(sanitize "$(basename "$CUR")")"
 
 CONTAINER="dw-sandbox-${SLUG}"
 
@@ -90,18 +135,20 @@ cache_mount_args() {
 
 # --print-plan: docker に一切触れず、解決結果を key=value 形式で出力するドライラン。
 # 「コンテナ名・イメージタグ・マウント元」を外から観測できる形にし、テストで固定するために用意する。
-# この時点では現行の解決結果をそのまま出す（挙動は変えない）。
-# repo_root / rel_path / fallback / build_context / compose_* は後続タスクで追加する。
+# build_context / compose_* は後続タスク（#8, #9）で追加する。
 print_plan() {
   printf 'mode=%s\n' "${DEV_WORKFLOW_SANDBOX_MODE:-}"
   printf 'repo=%s\n'  "$PROJECT"
   printf 'epic=%s\n'  "$EPIC"
+  printf 'repo_root=%s\n' "$HOST_ROOT"
+  printf 'rel_path=%s\n'  "$REL"
+  printf 'fallback=%s\n'  "$FALLBACK"
 
   case "${DEV_WORKFLOW_SANDBOX_MODE:-}" in
     dockerfile)
-      printf 'mount_source=%s\n' "$HOST_PWD"
+      printf 'mount_source=%s\n' "$MOUNT_SOURCE"
       printf 'mount_target=%s\n' "/workspace"
-      printf 'workdir=%s\n'      "/workspace"
+      printf 'workdir=%s\n'      "$WORKDIR"
       ;;
     *)
       printf 'mount_source=\n'
@@ -170,11 +217,24 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
     ;;
 
   dockerfile)
+    # 既存コンテナのマウント元が期待値（MOUNT_SOURCE）と異なる場合は、別ツリーを
+    # 実行してしまう経路になるため削除して作り直す（仕様書 4.3 の 2）。
+    # イメージID差分による再作成は #8 で追加する。
+    if docker container inspect "$CONTAINER" >/dev/null 2>&1; then
+      EXISTING_MOUNT="$(docker container inspect \
+        -f '{{ range .Mounts }}{{ if eq .Destination "/workspace" }}{{ .Source }}{{ end }}{{ end }}' \
+        "$CONTAINER" 2>/dev/null || true)"
+      if [ -n "$EXISTING_MOUNT" ] && [ "$EXISTING_MOUNT" != "$MOUNT_SOURCE" ]; then
+        echo "WARNING: 既存コンテナ ${CONTAINER} のマウント元 (${EXISTING_MOUNT}) が期待値 (${MOUNT_SOURCE}) と異なるため削除して作り直します（別ツリー実行の防止）" >&2
+        docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+      fi
+    fi
+
     # 常駐コンテナが無ければ起動する。sleep infinity で待機させ、以降は exec で叩く。
     if ! docker container inspect "$CONTAINER" >/dev/null 2>&1; then
       # shellcheck disable=SC2046  # マウント引数は意図的に単語分割する
       docker run -d --name "$CONTAINER" \
-        -v "${HOST_PWD}:/workspace" $(cache_mount_args) \
+        -v "${MOUNT_SOURCE}:/workspace" $(cache_mount_args) \
         -w /workspace "$DEV_WORKFLOW_SANDBOX_IMAGE" sleep infinity >/dev/null || {
           echo "ERROR: サンドボックスコンテナを起動できません: ${CONTAINER}" >&2
           exit 1
@@ -186,7 +246,7 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
       }
     fi
 
-    run_and_report docker exec -w /workspace "$CONTAINER" sh -c "$CMD"
+    run_and_report docker exec -w "$WORKDIR" "$CONTAINER" sh -c "$CMD"
     exit $?
     ;;
 

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -57,6 +57,8 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=lib/mount-path.sh
+. "${SCRIPT_DIR}/lib/mount-path.sh"
 # shellcheck source=lib/container-membership.sh
 . "${SCRIPT_DIR}/lib/container-membership.sh"
 # shellcheck source=lib/compose-conflicts.sh
@@ -77,7 +79,15 @@ ACTION="exec"
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --epic)        EPIC="${2:-}"; shift 2 ;;
+    --epic)
+      # 値が無いまま渡された場合、shift 2 は失敗して $# が減らず無限ループになる
+      # （実測: 残り引数が1個の状態で --epic を渡すと停止しない）。
+      # 引数個数を検査し、無ければ明快なエラーで停止する。
+      if [ $# -lt 2 ]; then
+        echo "ERROR: --epic には値が必要です" >&2
+        exit 2
+      fi
+      EPIC="$2"; shift 2 ;;
     --warm)        WARM=1; shift ;;
     --down)        ACTION="down"; shift ;;
     --all)         ALL=1; shift ;;
@@ -248,6 +258,7 @@ list_managed_candidate_names() {
 }
 
 MOUNT_SOURCE_TEMPLATE='{{ range .Mounts }}{{ if eq .Destination "/workspace" }}{{ .Source }}{{ end }}{{ end }}'
+LABEL_ROOT_TEMPLATE='{{ index .Config.Labels "dev-workflow.root" }}'
 
 list_managed() {
   local name label_repo label_epic image status created found=0
@@ -270,14 +281,15 @@ list_managed() {
 }
 
 down_all() {
-  local name label_repo mount_source
+  local name label_repo label_root mount_source
   local -a targets=()
 
   while IFS= read -r name; do
     [ -n "$name" ] || continue
     label_repo="$(container_field "$name" '{{ index .Config.Labels "dev-workflow.repo" }}')"
+    label_root="$(container_field "$name" "$LABEL_ROOT_TEMPLATE")"
     mount_source="$(container_field "$name" "$MOUNT_SOURCE_TEMPLATE")"
-    if container_belongs_to_repo "$label_repo" "$mount_source" "$HOST_ROOT" "$PROJECT"; then
+    if container_belongs_to_repo "$label_repo" "$label_root" "$mount_source" "$HOST_ROOT" "$PROJECT"; then
       targets+=("$name")
     fi
   done < <(list_managed_candidate_names)
@@ -305,13 +317,14 @@ down_all() {
 # （他 epic のものも含む）を対象にする。所属判定は down_all と同じ
 # container_belongs_to_repo を再利用し、重複実装しない。
 list_running_containers_in_repo() {
-  local name label_repo mount_source running
+  local name label_repo label_root mount_source running
 
   while IFS= read -r name; do
     [ -n "$name" ] || continue
     label_repo="$(container_field "$name" '{{ index .Config.Labels "dev-workflow.repo" }}')"
+    label_root="$(container_field "$name" "$LABEL_ROOT_TEMPLATE")"
     mount_source="$(container_field "$name" "$MOUNT_SOURCE_TEMPLATE")"
-    container_belongs_to_repo "$label_repo" "$mount_source" "$HOST_ROOT" "$PROJECT" || continue
+    container_belongs_to_repo "$label_repo" "$label_root" "$mount_source" "$HOST_ROOT" "$PROJECT" || continue
     running="$(container_field "$name" '{{.State.Running}}')"
     [ "$running" = "true" ] && printf '%s\n' "$name"
   done < <(list_managed_candidate_names)
@@ -486,8 +499,11 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
     if docker container inspect "$CONTAINER" >/dev/null 2>&1; then
       RECREATE=0
 
+      # マウント元の比較は正規化済み（normalize_mount_source）で行う。Windows +
+      # Docker Desktop では .Source が `/run/desktop/mnt/host/c/...` という
+      # Linux 側の変換済みパスで返るため、素の文字列比較では常に不一致になる（issue #25）。
       EXISTING_MOUNT="$(container_field "$CONTAINER" "$MOUNT_SOURCE_TEMPLATE")"
-      if [ -n "$EXISTING_MOUNT" ] && [ "$EXISTING_MOUNT" != "$MOUNT_SOURCE" ]; then
+      if [ -n "$EXISTING_MOUNT" ] && [ "$(normalize_mount_source "$EXISTING_MOUNT")" != "$(normalize_mount_source "$MOUNT_SOURCE")" ]; then
         echo "WARNING: 既存コンテナ ${CONTAINER} のマウント元 (${EXISTING_MOUNT}) が期待値 (${MOUNT_SOURCE}) と異なるため削除して作り直します（別ツリー実行の防止）" >&2
         RECREATE=1
       fi

--- a/scripts/sandbox-exec.sh
+++ b/scripts/sandbox-exec.sh
@@ -20,9 +20,22 @@
 #                                                                     # 同一リポジトリの管理コンテナが1つでも running
 #                                                                     # なら中断し、--force の指定を促す
 #   bash scripts/sandbox-exec.sh --reset-cache --force                # running でも強制的に削除する
+#   bash scripts/sandbox-exec.sh --rebuild 'make test'                # イメージを強制再ビルドしてから実行する
 #   bash scripts/sandbox-exec.sh --print-plan                        # docker に触れず解決結果を表示（ドライラン）
 #
 # 終了コードは実行したコマンドのものをそのまま返す（機械的ゲートの判定に使える）。
+#
+# イメージの自動ビルドと再作成（仕様書 4.7 / 4.3 の 1）:
+#   dockerfile モードでは、イメージが存在しない、または --rebuild 指定時に
+#   `docker build -f <Dockerfile> -t <イメージ> <ビルドコンテキスト>` を自動実行する。
+#   タグは resolve-sandbox.sh が Dockerfile の内容の hash から決めるため、内容が変われば
+#   自動的に別タグになる。ただし hash は Dockerfile 自体の内容しか見ないため、
+#   COPY 対象（go.mod / package.json 等）だけを変更した場合は検知できない。
+#   その逃げ道が --rebuild であり、内容に変更が無くても強制的に再ビルド・コンテナ作り直しを行う。
+#   DEV_WORKFLOW_DOCKER_IMAGE で既存イメージを明示指定した場合はビルド責務を持たない。
+#   イメージが無ければビルドせず、取得方法を示すエラーで停止する。
+#   既存の常駐コンテナのイメージIDが解決タグの現在のイメージIDと異なる場合も、
+#   バージョンスキュー解消のため削除して作り直す（理由を stderr に出す）。
 #
 # 参照する環境変数:
 #   DEV_WORKFLOW_CACHE_PATHS      volume 化するコンテナ内パス（スペース区切り）。既定は下記 DEFAULT_CACHE_PATHS
@@ -46,6 +59,7 @@ EPIC=""
 WARM=0
 ALL=0
 FORCE=0
+REBUILD=0
 ACTION="exec"
 
 while [ $# -gt 0 ]; do
@@ -57,6 +71,7 @@ while [ $# -gt 0 ]; do
     --ls)          ACTION="ls"; shift ;;
     --reset-cache) ACTION="reset-cache"; shift ;;
     --force)       FORCE=1; shift ;;
+    --rebuild)     REBUILD=1; shift ;;
     --print-plan)  ACTION="print-plan"; shift ;;
     --)            shift; break ;;
     -*)            echo "ERROR: 未知のオプション: $1" >&2; exit 2 ;;
@@ -149,7 +164,7 @@ cache_mount_args() {
 
 # --print-plan: docker に一切触れず、解決結果を key=value 形式で出力するドライラン。
 # 「コンテナ名・イメージタグ・マウント元」を外から観測できる形にし、テストで固定するために用意する。
-# build_context / compose_* は後続タスク（#8, #9）で追加する。
+# compose_* は後続タスク（#9）で追加する。
 print_plan() {
   printf 'mode=%s\n' "${DEV_WORKFLOW_SANDBOX_MODE:-}"
   printf 'repo=%s\n'  "$PROJECT"
@@ -173,6 +188,8 @@ print_plan() {
 
   printf 'container=%s\n' "$CONTAINER"
   printf 'image=%s\n'     "${DEV_WORKFLOW_SANDBOX_IMAGE:-}"
+  printf 'dockerfile=%s\n'     "${DEV_WORKFLOW_SANDBOX_DOCKERFILE:-}"
+  printf 'build_context=%s\n' "${DEV_WORKFLOW_SANDBOX_CONTEXT:-}"
 
   local path
   for path in $CACHE_PATHS; do
@@ -268,6 +285,41 @@ list_running_containers_in_repo() {
   done < <(list_managed_candidate_names)
 }
 
+# イメージ解決とビルド（仕様書 4.7）。
+# - DEV_WORKFLOW_SANDBOX_DOCKERFILE が非空（= Dockerfile.dev からビルドする運用）の場合は、
+#   イメージが存在しないか --rebuild 指定時に docker build を実行し、ビルド責務をここに集約する。
+# - DEV_WORKFLOW_SANDBOX_DOCKERFILE が空（= DEV_WORKFLOW_DOCKER_IMAGE で既存イメージを明示指定）
+#   の場合はビルドしない。イメージが無ければ、取得方法を示すエラーで停止する
+#   （利用者が用意した既存イメージの責務を勝手に肩代わりしないため）。
+image_exists() {
+  docker image inspect "$1" >/dev/null 2>&1
+}
+
+image_id_of() {
+  docker image inspect -f '{{.Id}}' "$1" 2>/dev/null || true
+}
+
+ensure_sandbox_image() {
+  if [ -n "$DEV_WORKFLOW_SANDBOX_DOCKERFILE" ]; then
+    if [ "$REBUILD" -eq 1 ] || ! image_exists "$DEV_WORKFLOW_SANDBOX_IMAGE"; then
+      echo "サンドボックスイメージをビルドします: ${DEV_WORKFLOW_SANDBOX_IMAGE} (${DEV_WORKFLOW_SANDBOX_DOCKERFILE})" >&2
+      docker build -f "$DEV_WORKFLOW_SANDBOX_DOCKERFILE" -t "$DEV_WORKFLOW_SANDBOX_IMAGE" "$DEV_WORKFLOW_SANDBOX_CONTEXT" || {
+        echo "ERROR: イメージのビルドに失敗しました: ${DEV_WORKFLOW_SANDBOX_IMAGE}" >&2
+        exit 1
+      }
+    fi
+  else
+    if [ "$REBUILD" -eq 1 ]; then
+      echo "WARNING: DEV_WORKFLOW_DOCKER_IMAGE 指定時はビルド責務を持たないため --rebuild を無視します" >&2
+    fi
+    if ! image_exists "$DEV_WORKFLOW_SANDBOX_IMAGE"; then
+      echo "ERROR: DEV_WORKFLOW_DOCKER_IMAGE=${DEV_WORKFLOW_SANDBOX_IMAGE} で指定されたイメージが見つかりません。" >&2
+      echo "       事前に 'docker pull' や 'docker build' 等でイメージを用意するか、DEV_WORKFLOW_DOCKER_IMAGE の指定を外して Dockerfile.dev からの自動ビルドを使ってください。" >&2
+      exit 1
+    fi
+  fi
+}
+
 eval "$(bash "${SCRIPT_DIR}/resolve-sandbox.sh")"
 
 case "$ACTION" in
@@ -349,13 +401,35 @@ case "$DEV_WORKFLOW_SANDBOX_MODE" in
     ;;
 
   dockerfile)
-    # 既存コンテナのマウント元が期待値（MOUNT_SOURCE）と異なる場合は、別ツリーを
-    # 実行してしまう経路になるため削除して作り直す（仕様書 4.3 の 2）。
-    # イメージID差分による再作成は #8 で追加する。
+    # イメージが無ければ自動ビルドする（--rebuild 指定時は強制的に再ビルドする）。
+    ensure_sandbox_image
+
+    # 既存コンテナは次のいずれかに該当すれば削除して作り直す（仕様書 4.3）:
+    #   1. イメージIDが解決タグの現在のイメージIDと異なる（バージョンスキュー解消）
+    #   2. マウント元が期待値（MOUNT_SOURCE）と異なる（別ツリー実行の防止）
+    #   3. --rebuild が明示指定されている（内容が変わっていなくても作り直す）
     if docker container inspect "$CONTAINER" >/dev/null 2>&1; then
+      RECREATE=0
+
       EXISTING_MOUNT="$(container_field "$CONTAINER" "$MOUNT_SOURCE_TEMPLATE")"
       if [ -n "$EXISTING_MOUNT" ] && [ "$EXISTING_MOUNT" != "$MOUNT_SOURCE" ]; then
         echo "WARNING: 既存コンテナ ${CONTAINER} のマウント元 (${EXISTING_MOUNT}) が期待値 (${MOUNT_SOURCE}) と異なるため削除して作り直します（別ツリー実行の防止）" >&2
+        RECREATE=1
+      fi
+
+      CURRENT_IMAGE_ID="$(image_id_of "$DEV_WORKFLOW_SANDBOX_IMAGE")"
+      EXISTING_IMAGE_ID="$(container_field "$CONTAINER" '{{.Image}}')"
+      if [ -n "$CURRENT_IMAGE_ID" ] && [ -n "$EXISTING_IMAGE_ID" ] && [ "$EXISTING_IMAGE_ID" != "$CURRENT_IMAGE_ID" ]; then
+        echo "WARNING: 既存コンテナ ${CONTAINER} のイメージ (${EXISTING_IMAGE_ID}) が現在のイメージ ${DEV_WORKFLOW_SANDBOX_IMAGE} (${CURRENT_IMAGE_ID}) と異なるため削除して作り直します（バージョンスキューの解消）" >&2
+        RECREATE=1
+      fi
+
+      if [ "$REBUILD" -eq 1 ]; then
+        echo "WARNING: --rebuild が指定されたため既存コンテナ ${CONTAINER} を削除して作り直します" >&2
+        RECREATE=1
+      fi
+
+      if [ "$RECREATE" -eq 1 ]; then
         docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
       fi
     fi

--- a/skills-codex/dev-workflow-run/SKILL.md
+++ b/skills-codex/dev-workflow-run/SKILL.md
@@ -52,31 +52,60 @@ cd "$EPIC_WT"
 
 ## サンドボックスの準備
 
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動はすべて `sandbox-exec.sh` に集約されている。
+やることは `--print-plan` で解決結果を確認し、`--warm` を1回流すことだけである。
+
 ```bash
-eval "$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-sandbox.sh")"
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-sandbox.sh" --print
+# docker に一切触れず、解決結果（mode / container / image / compose_* 等）を表示する
+PLAN="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan)"
+echo "$PLAN"
 
-case "$DEV_WORKFLOW_SANDBOX_MODE" in
-  dockerfile)
-    [ -n "$DEV_WORKFLOW_SANDBOX_DOCKERFILE" ] && \
-      docker build -f "$DEV_WORKFLOW_SANDBOX_DOCKERFILE" -t "$DEV_WORKFLOW_SANDBOX_IMAGE" .
-    ;;
-  compose)
-    docker compose -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" up -d
-    ;;
-  none)
-    echo "サンドボックス未設定。ホスト側のコマンドで検証する（テストが環境を汚す可能性を意識すること）"
-    ;;
-esac
+if printf '%s\n' "$PLAN" | grep -q '^mode=none$'; then
+  echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
+  echo "プロジェクトルートに開発用Dockerfileまたはcomposeファイルを配置してください"
+  exit 1
+fi
 
-# キャッシュを温めておく（最初のタスクにキャッシュ構築コストを負担させない）
+# キャッシュを温めておく（イメージが無ければここで自動ビルドされる。最初のタスクにキャッシュ構築コストを負担させない）
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --warm '<build-command>'
 ```
 
 **サンドボックスへのコマンド投入は `sandbox-exec.sh` 経由に統一する。** `docker run` を直接
-組み立ててはならない。キャッシュの永続化（`docker run --rm` はコンテナ層ごとビルドキャッシュを
-毎回捨てる）・コンテナの再利用・Windows のパス変換対策（Git Bash は `-w /workspace` を
+組み立ててはならない。イメージの解決とビルド（`Dockerfile.dev` の内容 hash でタグ付けし自動
+ビルドする。COPY 対象だけの変更を拾いたい場合は `--rebuild`）・キャッシュの永続化
+（`docker run --rm` はコンテナ層ごとビルドキャッシュを毎回捨てる。対象パスは
+`DEV_WORKFLOW_CACHE_PATHS` で上書き可）・コンテナの再利用（`--epic` 未指定時は
+`DEV_WORKFLOW_EPIC` を参照する）・Windows のパス変換対策（Git Bash は `-w /workspace` を
 `C:/Program Files/Git/workspace` に変換して失敗させる）をこのスクリプトが引き受ける。
+
+### compose を使う場合の要求仕様
+
+`docker-compose.dev.yml` を使う場合、常駐サービスが存在しないと `sandbox-exec.sh` が
+`exec` できない。次の要求仕様を満たすこと:
+
+- **常駐サービス名**: 既定 `app`（`DEV_WORKFLOW_COMPOSE_SERVICE` で変更可）
+- **マウント**: 当該サービスが `.:/workspace` をマウントすること
+  （異なるマウント先にする場合は `DEV_WORKFLOW_COMPOSE_WORKDIR` で上書きする）
+- **長時間常駐**: `sleep infinity` 等でプロセスが終了しないこと（running でなければ
+  `sandbox-exec.sh` は `up -d` を試みた上で、原因の分かるエラーを出して停止する）
+- **`container_name:` と固定ホストポート（例: `- "8080:8080"`）を使わないこと** —
+  `-p` では解決できない衝突であり、epic の並行実行ができなくなる。`sandbox-exec.sh` は
+  検出時に stderr へ警告するが、自動では直せない
+
+サンプル（そのまま貼り付けて使える最小構成）:
+
+```yaml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: ["sleep", "infinity"]
+```
 
 ## 自律実行の開始を記録
 
@@ -114,6 +143,9 @@ Task #<番号> を実装してください。
 - 作業ディレクトリ: <EPIC_WT>（ここから移動しないこと）
 - サンドボックスへのコマンド投入は `${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh` 経由で行い、
   ビルド・テストは1回の呼び出しにまとめること（分けると待ち時間が倍増する）
+- `sandbox-exec.sh` を呼ぶ際は必ず `--epic "$EPIC_NUM"` を渡すこと。省略すると環境変数
+  `DEV_WORKFLOW_EPIC` が参照されるので、渡し忘れた場合は `export DEV_WORKFLOW_EPIC="$EPIC_NUM"`
+  してから叩くこと。渡し忘れると Epic 単位のコンテナに載らずタスクごとに別コンテナが生まれる
 - 回帰確認はプロジェクトの全テストで行うこと。`-run` で絞った結果を「回帰なし」と報告しないこと
 - SKIP されたテストがあれば件数と内容を報告に含めること
 - issueの要件と、親Epic issue本文の仕様書・計画書を確認すること
@@ -171,6 +203,29 @@ gh issue close <番号>
 ```
 
 Epic issue の進捗チェックリストを更新し、Step 1 に戻る。
+
+## サンドボックスの後片付け（正常終了・異常終了を問わず必ず実行）
+
+自律ループが終わる経路は複数ある（全タスク完了 → Epic一括レビュー → PR作成、機械的ゲートの
+失敗が続いてタスクをスキップし続けた末の停止、予期しないエラーによる中断）。
+**どの経路で終わる場合も、後続処理（PR作成や中断報告）に進む前に、必ず次のクリーンアップを
+実行すること。** 完了通知の後ろに置いて成功時にしか実行されない、ということがあってはならない。
+
+```bash
+# 常駐コンテナの削除（epic 単位。キャッシュ volume は次の Epic のために残す）
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --down
+```
+
+**キャッシュ volume は削除しない。** 次の Epic でそのまま効くのが利点である。明示的に消したい
+場合のみ `--reset-cache` を使う（**作用範囲は epic ではなくリポジトリ全体**。同一リポジトリの
+他 epic のコンテナが running なら中断され、続けるには `--force` が必要）。
+
+自律実行の外で残存コンテナを棚卸ししたい場合は次を使う:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --ls          # 管理コンテナを一覧表示（他リポジトリ分も含む）
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --down --all   # 現在のリポジトリに属する管理コンテナを全て削除
+```
 
 ## Epic一括レビュー（全タスク完了後・PR作成前）
 
@@ -268,7 +323,11 @@ PR: <PRのURL>"
 
 到達せず終了した場合は Stop フックが「自律実行が停止」として自動通知する。
 
-## クリーンアップ
+## クリーンアップ（worktree）
+
+サンドボックスの後片付け（常駐コンテナの `--down`）は「Step 5: 取り込んで次へ」の直後の節で
+**既に実行済み**である（正常終了・異常終了を問わず必ず実行する節）。ここでは worktree のみを
+片付ける。
 
 ```bash
 # worktree の削除前に node_modules 等の symlink を解除する
@@ -277,15 +336,7 @@ cd "$(git rev-parse --show-toplevel)"
 find ".codex/worktrees/${EPIC_NUM}" -maxdepth 2 -type l -name node_modules -exec unlink {} \; 2>/dev/null || true
 git worktree remove ".codex/worktrees/${EPIC_NUM}" --force 2>/dev/null || true
 git worktree prune
-
-docker compose -f "$DEV_WORKFLOW_SANDBOX_COMPOSE" down 2>/dev/null || true
-
-# 常駐コンテナの削除（キャッシュ volume は次の Epic のために残す）
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --down 2>/dev/null || true
 ```
-
-**キャッシュ volume は削除しない。** 次の Epic でそのまま効くのが利点である。
-明示的に消したい場合のみ `--reset-cache` を使う。
 
 ## 自律動作ポリシー
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -86,25 +86,28 @@ worktree内から実行してもマーカーはメインリポのルートに置
 
 ### Docker sandbox の準備
 
-**まず作業 worktree に移動してから**、実装・テスト用のDockerコンテナを起動する（以降 `pwd` は
-`$EPIC_WT`。マウント・ビルドはこの worktree を基点に行う）:
+**まず作業 worktree に移動してから**、`sandbox-exec.sh` でサンドボックスを準備する（以降 `pwd` は
+`$EPIC_WT`。マウント・イメージ解決はこの worktree を基点に行う）。
+
+**`docker build` / `docker compose up` を直接叩いてはならない。** イメージのビルド・
+コンテナの起動・compose サービスの起動はすべて `sandbox-exec.sh` に集約されている（後述）。
+スキル側がやることは、`--print-plan` で解決結果を確認し、`--warm` を1回流すことだけである。
 
 ```bash
 cd "$EPIC_WT"   # 以降の作業ディレクトリを Epic 専用 worktree に固定
 
-# Dockerfile.dev / docker-compose.dev.yml は worktree にも存在する（フルチェックアウトのため）
-# プロジェクトルートに Dockerfile.dev があればビルド、なければ設定されたイメージを使用
-if [ -f Dockerfile.dev ]; then
-  docker build -f Dockerfile.dev -t dev-sandbox:$(basename $(pwd)) .
-  SANDBOX_IMAGE="dev-sandbox:$(basename $(pwd))"
-elif [ -f docker-compose.dev.yml ]; then
-  docker compose -f docker-compose.dev.yml up -d
-  SANDBOX_IMAGE="" # docker compose経由で実行
-else
+# docker に一切触れず、解決結果（mode / container / image / compose_* 等）を表示する
+PLAN="$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --print-plan)"
+echo "$PLAN"
+
+if printf '%s\n' "$PLAN" | grep -q '^mode=none$'; then
   echo "ERROR: Dockerfile.dev または docker-compose.dev.yml が見つかりません"
-  echo "プロジェクトルートに開発用Dockerfileを配置してください"
+  echo "プロジェクトルートに開発用Dockerfileまたはcomposeファイルを配置してください"
   exit 1
 fi
+
+# キャッシュを温める（イメージが無ければここで自動ビルドされる。最初のタスクにビルドコストを負担させない）
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --warm '[build-command]'
 ```
 
 コンテナ内でコードをマウントし、全ての実装・テスト・ビルドコマンドをコンテナ内で実行する。
@@ -114,26 +117,55 @@ Gitオペレーション（commit, push等）はホスト側で実行する。
 
 **`docker run` を直接組み立ててはならない。** 以下をすべて `scripts/sandbox-exec.sh` が引き受ける:
 
+- **イメージの解決とビルド** — `Dockerfile.dev` があれば内容の hash でタグ付けして自動ビルドする
+  （`DEV_WORKFLOW_DOCKER_IMAGE` を指定すれば既存イメージをそのまま使い、ビルドはしない）
 - **ビルドキャッシュの永続化** — `docker run --rm` はコンテナ層を毎回捨てるため、`GOCACHE` 等に
   貯まったコンパイル結果が次回に残らない。言語ごとのキャッシュディレクトリを named volume 化する
-- **コンテナの再利用** — Epic 単位で常駐させ `docker exec` で叩き、起動オーバーヘッドを消す
+  （対象パスは `DEV_WORKFLOW_CACHE_PATHS` で上書きできる）
+- **コンテナの再利用** — Epic 単位で常駐させ `docker exec` で叩き、起動オーバーヘッドを消す。
+  `--epic` を渡し忘れても環境変数 `DEV_WORKFLOW_EPIC` が設定されていれば同じコンテナに載る
 - **Windows のパス変換対策** — Git Bash（MSYS）は `-w /workspace` を
   `C:/Program Files/Git/workspace` に変換してしまい、`docker run` がそのまま失敗する。
   `MSYS_NO_PATHCONV=1` と `pwd -W` で回避する
-- **イメージタグの安定化** — タグをリポジトリ名基準にし、worktree ごとに別イメージを
-  ビルドし直す事故を防ぐ
+- **イメージタグの安定化** — タグをリポジトリ名基準（+ Dockerfile の内容 hash）にし、worktree
+  ごとに別イメージをビルドし直す事故を防ぐ。COPY 対象だけを変更した場合は hash が変わらないため、
+  その場合は `--rebuild` で強制的に再ビルド・コンテナ作り直しを行う
 
 ```bash
 # 実行（複数コマンドは1回にまとめる。後述）
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" 'make test'
-
-# キャッシュを温める（最初のタスクにキャッシュ構築コストを負担させない）
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --warm '[build-command]'
 ```
 
 終了コードは実行したコマンドのものがそのまま返るので、機械的ゲートの判定に使える。
 
-Docker sandbox の準備が終わったら、続けて `--warm` を1回流しておく。
+### compose を使う場合の要求仕様
+
+`docker-compose.dev.yml` を使う場合、素直に「ビルド・テストを実行する compose ファイル」を
+書くと常駐サービスが存在せず `sandbox-exec.sh` が `exec` できない。次の要求仕様を満たすこと:
+
+- **常駐サービス名**: 既定 `app`（`DEV_WORKFLOW_COMPOSE_SERVICE` で変更可）
+- **マウント**: 当該サービスが `.:/workspace` をマウントすること
+  （異なるマウント先にする場合は `DEV_WORKFLOW_COMPOSE_WORKDIR` で上書きする）
+- **長時間常駐**: `sleep infinity` 等でプロセスが終了しないこと（サービスが running であり
+  続けないと `sandbox-exec.sh` は `up -d` を試みた上で、原因の分かるエラーを出して停止する）
+- **`container_name:` と固定ホストポート（例: `- "8080:8080"`）を使わないこと** —
+  `sandbox-exec.sh` は `-p <project>` でプロジェクト名を epic 単位に分離するが、これらは
+  `-p` では解決できない衝突であり、epic の並行実行ができなくなる。`sandbox-exec.sh` は
+  検出時に stderr へ警告するが、自動では直せない
+
+サンプル（そのまま貼り付けて使える最小構成）:
+
+```yaml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    command: ["sleep", "infinity"]
+```
 
 ## 2エージェント体制
 
@@ -219,6 +251,11 @@ Task #[番号] を実装してください。
   でベースを検証すること。偽なら実装を始めず、実出力を添えて報告し停止すること
 - サンドボックスへのコマンド投入は `${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh` 経由で行い、
   ビルド・テストは1回の呼び出しにまとめること（分けると待ち時間が倍増する）
+- `sandbox-exec.sh` を呼ぶ際は必ず `--epic "$EPIC_NUM"` を渡すこと（例: `--epic "$EPIC_NUM" 'make test'`）。
+  省略すると環境変数 `DEV_WORKFLOW_EPIC` が参照されるので、渡し忘れた場合は
+  `export DEV_WORKFLOW_EPIC="$EPIC_NUM"` してから叩くこと。あなたは isolation worktree
+  （`.claude/worktrees/agent-*`）で動くため、これを怠ると Epic 単位のコンテナに載らず
+  タスクごとに別コンテナが生まれる
 - 回帰確認はプロジェクトの全テストで行うこと。`-run` で絞った結果を「回帰なし」と報告しないこと
 - SKIP されたテストがあれば件数と内容を報告に含めること
 - issueの要件を確認
@@ -304,6 +341,33 @@ git cherry-pick "${EPIC_BRANCH}..[作業ブランチ]"
 4. → Step 1 に戻る（次のタスクへ）
 
 全タスクが完了したら **「Epic一括レビュー」** へ進む。
+
+## サンドボックスの後片付け（正常終了・異常終了を問わず必ず実行）
+
+自律ループが終わる経路は複数ある（全タスク完了 → Epic一括レビュー → PR作成、機械的ゲートの
+失敗が続いてタスクをスキップし続けた末の停止、予期しないエラーによる中断）。
+**どの経路で run が終わる場合も、後続処理（PR作成や中断報告）に進む前に、必ず次のクリーンアップを
+実行すること。** 完了通知の後ろに置いて成功時にしか実行されない、ということがあってはならない。
+
+```bash
+# 常駐コンテナの削除（epic 単位。キャッシュ volume は次の Epic のために残す）
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --down
+```
+
+**キャッシュ volume は削除しない。** 次の Epic でそのまま効くのが利点であり、消すと
+毎回キャッシュ構築コストを払い直すことになる。明示的に消したい場合のみ `--reset-cache` を使う。
+`--reset-cache` の**作用範囲は epic ではなくリポジトリ全体**であることに注意し、
+同一リポジトリの他 epic のコンテナが running なら中断される（続けるには `--force`。
+他 epic の実行中コンテナのキャッシュも壊れるため、本当に必要な場合のみ使うこと）。
+
+### 人間向けの手動クリーンアップ
+
+自律実行の外で、残存コンテナの棚卸しをしたい場合は次を使う:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --ls          # 管理コンテナを一覧表示（他リポジトリ分も含む）
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --down --all   # 現在のリポジトリに属する管理コンテナを全て削除
+```
 
 ## 進捗表示
 
@@ -507,21 +571,9 @@ fi
 git worktree prune
 ```
 
-## Docker sandbox クリーンアップ
-
-全タスク完了後またはエラー終了時にDockerリソースを停止・削除する:
-
-```bash
-# docker compose使用時
-docker compose -f docker-compose.dev.yml down 2>/dev/null || true
-
-# 常駐コンテナの削除（キャッシュ volume は次の Epic のために残す）
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/sandbox-exec.sh" --epic "$EPIC_NUM" --down 2>/dev/null || true
-```
-
-**キャッシュ volume は削除しない。** 次の Epic でそのまま効くのが利点であり、消すと
-毎回キャッシュ構築コストを払い直すことになる。ディスクを空けたい等の理由で明示的に
-消したい場合のみ `--reset-cache` を使う。
+サンドボックスの後片付け（常駐コンテナの `--down`）は「Epicブランチに取り込んで次のタスクへ」の
+直後の節で**既に実行済み**である（正常終了・異常終了を問わず必ず実行する節）。ここで重複して
+実行する必要はない。
 
 ## 自律動作ポリシー（YOLOモード）
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1985,6 +1985,125 @@ check_no_forbidden_sandbox_calls "agents/ に docker 直接呼び出しが残っ
 check_no_forbidden_sandbox_calls "codex-agents/ に docker 直接呼び出しが残っていない" "${REPO_ROOT}/codex-agents"
 
 # ---------------------------------------------------------------------------
+# check-readability.sh: 複数行フックJSONの読み取り（回帰防止 #31）
+#
+# Task #10 のハング修正で stdin を「上限付きで読む」形にした際、実装が
+# `read -r -t` を1回しか呼ばず先頭1行しか読んでいなかった。フック入力は
+# 整形された（複数行の）JSONで来ることがあり、1行目に file_path が無い場合
+# 検査対象を取りこぼして警告もログも無く exit 0 してしまう欠陥があった
+# （可読性ガードが最優先で守るルールが、入力形式の差で黙って無効化される）。
+#
+# ここでは stdin 全体をタイムアウト付きで読み切る修正後の実装が、
+#   1) 複数行JSONでも file_path を抽出して違反を検出できること
+#   2) 1行目に file_path が無い複数行JSONでも検出できること
+#   3) Task #10 で固定した「stdinを開いたままでもハングしない」性質を
+#      壊していないこと
+# を確認する。
+# ---------------------------------------------------------------------------
+
+echo "== check-readability.sh（複数行フックJSONの読み取り・回帰防止 #31） =="
+
+RG31_TMP_REPO="$(make_temp_repo)"
+RG31_VIOLATION_FILE="violation.txt"
+(
+  cd "$RG31_TMP_REPO" || exit 1
+  head -c 3000 /dev/zero | tr '\0' 'A' > "$RG31_VIOLATION_FILE"
+) >/dev/null 2>&1
+
+# --- 整形された（複数行の）フックJSON。file_path は先頭行ではなく途中の行にある ---
+RG31_MULTILINE_JSON=$(cat <<EOF
+{
+  "session_id": "abc123",
+  "tool_input": {
+    "file_path": "${RG31_VIOLATION_FILE}"
+  },
+  "tool_name": "Write"
+}
+EOF
+)
+
+RG31_MULTILINE_EXIT=0
+(
+  cd "$RG31_TMP_REPO" || exit 1
+  printf '%s' "$RG31_MULTILINE_JSON" \
+    | READABILITY_MAX_BASE64=50 bash "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG31_MULTILINE_EXIT=$?
+assert_exit_code "複数行に整形されたフックJSONでもfile_pathを抽出して違反を検出する" 2 "$RG31_MULTILINE_EXIT"
+
+# --- 1行目に file_path が無い複数行JSON（file_path はJSONの末尾近くの行にある） ---
+RG31_LATE_FIELD_JSON=$(cat <<EOF
+{
+  "session_id": "abc123",
+  "cwd": "/tmp/somewhere",
+  "hook_event_name": "PostToolUse",
+  "tool_name": "Write",
+  "tool_input": {
+    "content": "dummy",
+    "file_path": "${RG31_VIOLATION_FILE}"
+  }
+}
+EOF
+)
+
+RG31_LATE_FIELD_EXIT=0
+(
+  cd "$RG31_TMP_REPO" || exit 1
+  printf '%s' "$RG31_LATE_FIELD_JSON" \
+    | READABILITY_MAX_BASE64=50 bash "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG31_LATE_FIELD_EXIT=$?
+assert_exit_code "1行目にfile_pathが無い複数行JSONでも検出できる" 2 "$RG31_LATE_FIELD_EXIT"
+
+# --- 上記と同じ複数行JSONで、クリーンなファイルならexit 0（誤検出しないことの確認） ---
+RG31_CLEAN_FILE="clean-multiline.txt"
+(
+  cd "$RG31_TMP_REPO" || exit 1
+  printf 'clean file\n' > "$RG31_CLEAN_FILE"
+) >/dev/null 2>&1
+
+RG31_CLEAN_MULTILINE_JSON=$(cat <<EOF
+{
+  "session_id": "abc123",
+  "tool_input": {
+    "file_path": "${RG31_CLEAN_FILE}"
+  }
+}
+EOF
+)
+
+RG31_CLEAN_MULTILINE_EXIT=0
+(
+  cd "$RG31_TMP_REPO" || exit 1
+  printf '%s' "$RG31_CLEAN_MULTILINE_JSON" | bash "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG31_CLEAN_MULTILINE_EXIT=$?
+assert_exit_code "複数行JSONでもクリーンなファイルはexit 0（誤検出しない）" 0 "$RG31_CLEAN_MULTILINE_EXIT"
+
+# --- Task #10 の性質を壊していないことの再確認: stdinを開いたまま --git を叩いても即座に返る ---
+# RG31_TMP_REPO には未追跡の違反ファイル（violation.txt等）があるため、
+# --git で検査すれば違反検出（exit 2）になり得る。ここで確認したいのは
+# 「ハングしないこと」だけなので、違反ファイルの無いクリーンな一時リポジトリを別途使う。
+RG31_HANG_REPO="$(make_temp_repo)"
+RG31_GIT_HANG_EXIT=0
+(
+  cd "$RG31_HANG_REPO" || exit 1
+  timeout 8 bash "$CHECK_READABILITY_SCRIPT" --git < <(sleep 30) >/dev/null 2>&1
+)
+RG31_GIT_HANG_EXIT=$?
+assert_exit_code "stdinを開いたまま--gitを叩いても即座に返る（ハング再発なし）" 0 "$RG31_GIT_HANG_EXIT"
+
+# --- 引数なし・非ttyで入力が来ない場合も、複数行読み取りに変えた後で引き続きタイムアウトする ---
+RG31_TIMEOUT_EXIT=0
+(
+  cd "$RG31_HANG_REPO" || exit 1
+  timeout 8 env READABILITY_STDIN_TIMEOUT=1 bash "$CHECK_READABILITY_SCRIPT" \
+    < <(sleep 30) >/dev/null 2>&1
+)
+RG31_TIMEOUT_EXIT=$?
+assert_exit_code "複数行読み取りに変えた後も、入力が来ない場合はタイムアウトしてexit 0で素通りする" 0 "$RG31_TIMEOUT_EXIT"
+
+# ---------------------------------------------------------------------------
 # 結果集計
 # ---------------------------------------------------------------------------
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1622,6 +1622,72 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# .gitattributes の eol=lf カバレッジ（回帰防止）
+#
+# *.toml（adapters/*/overlays/*.toml・codex-agents/*.toml）に eol=lf 指定が無かったため、
+# core.autocrlf=true の環境でワーキングツリー上の *.toml が CRLF 化され、
+# adapters/codex/build.sh の include 展開（1行ずつの case 一致）が壊れて
+# `build.sh --check` が生成物を誤って STALE 判定する事故が実際に発生した。
+# 同じ障害クラスが *.sh / *.toml のどちらでも起きないことを検証する。
+#
+# このリポジトリ自身（REPO_ROOT）に対して直接 git check-attr を呼ばないのは、
+# generator の worktree（.claude/worktrees/agent-*）はリンク済みworktreeであり、
+# サンドボックスのバインドマウント経由では .git ファイルが指す gitdir の絶対パスが
+# 解決できず `fatal: not a git repository` になる環境依存の問題があるため。
+# 実際に使う .gitattributes の内容を、worktree に依存しない素の一時リポジトリへ
+# コピーして検証する（他のテストケースの make_temp_repo と同じ考え方）。
+# ---------------------------------------------------------------------------
+
+echo "== .gitattributes の eol=lf カバレッジ（回帰防止） =="
+
+GITATTRIBUTES_TEST_REPO="$(make_temp_repo)"
+cp "${REPO_ROOT}/.gitattributes" "${GITATTRIBUTES_TEST_REPO}/.gitattributes"
+(
+  cd "$GITATTRIBUTES_TEST_REPO" || exit 1
+  git add .gitattributes
+  git commit -q -m "add .gitattributes"
+) >/dev/null 2>&1
+
+check_eol_lf() {
+  # check_eol_lf <repo> <プローブ用パス（repo内の任意の相対パスでよい）>
+  # git check-attr eol の解決結果が lf なら true を返す（Docker 非依存）。
+  local repo="$1" probe_path="$2"
+  local eol
+  eol="$(cd "$repo" && git check-attr eol -- "$probe_path" 2>/dev/null | sed -n 's/^.*: eol: //p')"
+  [ "$eol" = "lf" ]
+}
+
+if check_eol_lf "$GITATTRIBUTES_TEST_REPO" "dev-workflow-gitattributes-probe.sh"; then
+  pass ".gitattributes: *.sh の eol 解決が lf である"
+else
+  fail ".gitattributes: *.sh の eol 解決が lf である" "check-attr の解決結果が lf ではありませんでした"
+fi
+
+if check_eol_lf "$GITATTRIBUTES_TEST_REPO" "dev-workflow-gitattributes-probe.toml"; then
+  pass ".gitattributes: *.toml の eol 解決が lf である"
+else
+  fail ".gitattributes: *.toml の eol 解決が lf である" "check-attr の解決結果が lf ではありませんでした"
+fi
+
+if check_eol_lf "$GITATTRIBUTES_TEST_REPO" "adapters/codex/overlays/dev-workflow-gitattributes-probe.toml"; then
+  pass ".gitattributes: adapters/codex/overlays/ 配下の *.toml も eol=lf が効く"
+else
+  fail ".gitattributes: adapters/codex/overlays/ 配下の *.toml も eol=lf が効く" "check-attr の解決結果が lf ではありませんでした"
+fi
+
+if check_eol_lf "$GITATTRIBUTES_TEST_REPO" "codex-agents/dev-workflow-gitattributes-probe.toml"; then
+  pass ".gitattributes: codex-agents/ 配下の *.toml も eol=lf が効く"
+else
+  fail ".gitattributes: codex-agents/ 配下の *.toml も eol=lf が効く" "check-attr の解決結果が lf ではありませんでした"
+fi
+
+if check_eol_lf "$GITATTRIBUTES_TEST_REPO" ".gitattributes"; then
+  pass ".gitattributes: .gitattributes 自身の eol 解決も lf である（自己参照ルール）"
+else
+  fail ".gitattributes: .gitattributes 自身の eol 解決も lf である（自己参照ルール）" "check-attr の解決結果が lf ではありませんでした"
+fi
+
+# ---------------------------------------------------------------------------
 # 結果集計
 # ---------------------------------------------------------------------------
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1349,6 +1349,132 @@ case "$COMPOSE_WARN_STDERR" in
 esac
 
 # ---------------------------------------------------------------------------
+# CRLF 警告（crlf_warning_message、Docker 非依存の純粋関数、Task #11、Epic #3 仕様書 4.10）
+#
+# check-prerequisites.sh を source しても本体（gh/docker/git リポジトリチェック等）が
+# 実行されないことを利用し、crlf_warning_message だけを直接呼び出して検証する。
+# 一時 git リポジトリの core.autocrlf / .gitattributes を組み合わせて条件を再現する。
+# ---------------------------------------------------------------------------
+
+echo "== crlf_warning_message（CRLF警告・Docker非依存。Task #11） =="
+
+CHECK_PREREQS_SCRIPT="${REPO_ROOT}/scripts/check-prerequisites.sh"
+
+make_crlf_test_repo() {
+  # make_crlf_test_repo <autocrlf値> <gitattributes内容 or 空>
+  # core.autocrlf と .gitattributes を指定して一時リポジトリを作り、パスを返す。
+  local autocrlf="$1" attrs="$2"
+  local dir
+  dir="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-crlf-repo.XXXXXX")"
+  (
+    cd "$dir" || exit 1
+    git init -q
+    git config user.email "dev-workflow-test@example.com"
+    git config user.name "dev-workflow test"
+    git config core.autocrlf "$autocrlf"
+    if [ -n "$attrs" ]; then
+      printf '%s\n' "$attrs" > .gitattributes
+    fi
+  ) >/dev/null 2>&1
+  printf '%s' "$dir"
+}
+
+crlf_warning_in() {
+  # crlf_warning_in <dir>  <dir> 内で check-prerequisites.sh を source し
+  # crlf_warning_message を呼び出した標準出力を返す（stderr は捨てる）。
+  local dir="$1"
+  (
+    cd "$dir" || exit 1
+    # shellcheck source=../scripts/check-prerequisites.sh
+    source "$CHECK_PREREQS_SCRIPT"
+    crlf_warning_message
+  ) 2>/dev/null
+}
+
+# --- autocrlf=true かつ .gitattributes に *.sh の eol=lf が無ければ警告が出る ---
+CRLF_NOATTR_REPO="$(make_crlf_test_repo true "")"
+CRLF_NOATTR_WARNING="$(crlf_warning_in "$CRLF_NOATTR_REPO")"
+
+if [ -n "$CRLF_NOATTR_WARNING" ]; then
+  pass "autocrlf=true かつ eol=lf 未設定なら警告が出る"
+else
+  fail "autocrlf=true かつ eol=lf 未設定なら警告が出る" "警告が空でした"
+fi
+
+case "$CRLF_NOATTR_WARNING" in
+  *".gitattributes"*) pass "警告文に .gitattributes への言及がある" ;;
+  *) fail "警告文に .gitattributes への言及がある" "warning=[${CRLF_NOATTR_WARNING}]" ;;
+esac
+
+case "$CRLF_NOATTR_WARNING" in
+  *"*.sh text eol=lf"*) pass "警告文に *.sh text eol=lf の追記案内がある" ;;
+  *) fail "警告文に *.sh text eol=lf の追記案内がある" "warning=[${CRLF_NOATTR_WARNING}]" ;;
+esac
+
+if printf '%s' "$CRLF_NOATTR_WARNING" | grep -qF '$'"'"'{\r'"'"''; then
+  pass "警告文に構文エラーの症状（\$'{\\r'）が含まれる"
+else
+  fail "警告文に構文エラーの症状（\$'{\\r'）が含まれる" "warning=[${CRLF_NOATTR_WARNING}]"
+fi
+
+# --- autocrlf=true でも .gitattributes に *.sh text eol=lf があれば警告は出ない ---
+CRLF_WITHATTR_REPO="$(make_crlf_test_repo true "*.sh text eol=lf")"
+CRLF_WITHATTR_WARNING="$(crlf_warning_in "$CRLF_WITHATTR_REPO")"
+
+assert_eq "autocrlf=true でも *.sh text eol=lf があれば警告が出ない" "" "$CRLF_WITHATTR_WARNING"
+
+# --- autocrlf=false なら警告は出ない ---
+CRLF_FALSE_REPO="$(make_crlf_test_repo false "")"
+CRLF_FALSE_WARNING="$(crlf_warning_in "$CRLF_FALSE_REPO")"
+
+assert_eq "autocrlf=false なら警告が出ない" "" "$CRLF_FALSE_WARNING"
+
+# --- autocrlf=input でも警告は出ない（true のときだけが対象） ---
+CRLF_INPUT_REPO="$(make_crlf_test_repo input "")"
+CRLF_INPUT_WARNING="$(crlf_warning_in "$CRLF_INPUT_REPO")"
+
+assert_eq "autocrlf=input なら警告が出ない" "" "$CRLF_INPUT_WARNING"
+
+# --- 警告が出るケースでも check-prerequisites.sh 全体の終了コードは変わらない（exit 2 でブロックしない） ---
+#
+# check-prerequisites.sh 本体は gh/docker の実コマンドを呼び、gh 認証済みなら
+# `git config --global credential.helper` まで書き換える副作用を持つ。テストで
+# 実ホストの状態を変えないよう、gh/docker は偽コマンドに差し替え、--global の参照先も
+# 隔離した HOME に向ける（実際の docker/gh には一切触れない）。
+CRLF_FAKE_BIN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-crlf-fakebin.XXXXXX")"
+cat > "${CRLF_FAKE_BIN_DIR}/gh" <<'FAKE_GH'
+#!/bin/bash
+# tests/run-tests.sh 用の偽 gh。認証済み扱いにして常に成功させる。
+exit 0
+FAKE_GH
+chmod +x "${CRLF_FAKE_BIN_DIR}/gh"
+cat > "${CRLF_FAKE_BIN_DIR}/docker" <<'FAKE_DOCKER_PREREQ'
+#!/bin/bash
+# tests/run-tests.sh 用の偽 docker。起動済み扱いにして常に成功させる。
+exit 0
+FAKE_DOCKER_PREREQ
+chmod +x "${CRLF_FAKE_BIN_DIR}/docker"
+
+CRLF_FAKE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-crlf-fakehome.XXXXXX")"
+printf '[credential]\n\thelper = gh\n' > "${CRLF_FAKE_HOME}/.gitconfig"
+
+CRLF_FULL_STDERR="$(mktemp "${TMPDIR:-/tmp}/dw-test-crlf-full-stderr.XXXXXX")"
+CRLF_FULL_EXIT=0
+(
+  cd "$CRLF_NOATTR_REPO" || exit 1
+  HOME="$CRLF_FAKE_HOME" PATH="${CRLF_FAKE_BIN_DIR}:${PATH}" \
+    bash "$CHECK_PREREQS_SCRIPT" 1>/dev/null 2>"$CRLF_FULL_STDERR"
+) || CRLF_FULL_EXIT=$?
+
+assert_exit_code "偽gh/偽dockerが揃った状態でCRLF警告があっても exit 0（ブロックしない）" 0 "$CRLF_FULL_EXIT"
+
+if grep -q "core.autocrlf=true" "$CRLF_FULL_STDERR"; then
+  pass "check-prerequisites.sh 本体からも CRLF 警告が stderr に出る"
+else
+  fail "check-prerequisites.sh 本体からも CRLF 警告が stderr に出る" "stderr=[$(cat "$CRLF_FULL_STDERR")]"
+fi
+
+# ---------------------------------------------------------------------------
 # 結果集計
 # ---------------------------------------------------------------------------
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1688,6 +1688,39 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 役割定義・生成物に docker 直接呼び出しの記述が残っていない（回帰防止 #26）
+#
+# core/roles/evaluator.md の「テスト実行（サンドボックス内）」節が、イメージタグを
+# hash 付けに変えた本Epicの変更に追随せず、`docker run --rm ... dev-sandbox:[project]` /
+# `docker compose -f docker-compose.dev.yml exec app` という旧い直接呼び出しのまま
+# 生成物（agents/evaluator.md・codex-agents/evaluator.toml）に伝播していた。
+# Task #12・#13 が対象ファイル一覧に evaluator.md を含めていなかったことが原因なので、
+# ファイル名を列挙するのではなく core/roles・agents・codex-agents をディレクトリごと
+# 走査する。core/instructions.md も同じ理由で対象に含める。
+# ---------------------------------------------------------------------------
+
+echo "== 役割定義・生成物に docker 直接呼び出しの記述が残っていない（回帰防止 #26） =="
+
+FORBIDDEN_SANDBOX_PATTERN='docker run --rm|dev-sandbox:\[project\]|docker compose -f docker-compose\.dev\.yml exec'
+
+check_no_forbidden_sandbox_calls() {
+  # check_no_forbidden_sandbox_calls <説明> <検査対象（ファイルまたはディレクトリ）>
+  local desc="$1" target="$2"
+  local hits
+  hits="$(grep -rnE "$FORBIDDEN_SANDBOX_PATTERN" "$target" 2>/dev/null || true)"
+  if [ -z "$hits" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "$hits"
+  fi
+}
+
+check_no_forbidden_sandbox_calls "core/roles/ に docker 直接呼び出しが残っていない" "${REPO_ROOT}/core/roles"
+check_no_forbidden_sandbox_calls "core/instructions.md に docker 直接呼び出しが残っていない" "${REPO_ROOT}/core/instructions.md"
+check_no_forbidden_sandbox_calls "agents/ に docker 直接呼び出しが残っていない" "${REPO_ROOT}/agents"
+check_no_forbidden_sandbox_calls "codex-agents/ に docker 直接呼び出しが残っていない" "${REPO_ROOT}/codex-agents"
+
+# ---------------------------------------------------------------------------
 # 結果集計
 # ---------------------------------------------------------------------------
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -90,13 +90,14 @@ make_worktree() {
 
 copy_sandbox_scripts() {
   # copy_sandbox_scripts <dest_repo_dir>
-  # sandbox-exec.sh / resolve-sandbox.sh / Dockerfile.dev を検証対象の一時リポジトリへ複製する。
+  # sandbox-exec.sh / resolve-sandbox.sh / lib / Dockerfile.dev を検証対象の一時リポジトリへ複製する。
   # worktree はコミット済みの内容しか見えないため、複製後にコミットまで済ませる
   # （worktree からもスクリプトを実行できるようにするため）。
   local dest="$1"
-  mkdir -p "${dest}/scripts"
-  cp "${REPO_ROOT}/scripts/sandbox-exec.sh"   "${dest}/scripts/sandbox-exec.sh"
+  mkdir -p "${dest}/scripts/lib"
+  cp "${REPO_ROOT}/scripts/sandbox-exec.sh"    "${dest}/scripts/sandbox-exec.sh"
   cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
+  cp "${REPO_ROOT}/scripts/lib/container-membership.sh" "${dest}/scripts/lib/container-membership.sh"
   cp "${REPO_ROOT}/Dockerfile.dev"             "${dest}/Dockerfile.dev"
   (
     cd "$dest" || exit 1
@@ -111,7 +112,7 @@ copy_sandbox_scripts() {
 
 echo "== bash -n（構文チェック） =="
 
-for script in "${REPO_ROOT}"/scripts/*.sh; do
+for script in "${REPO_ROOT}"/scripts/*.sh "${REPO_ROOT}"/scripts/lib/*.sh; do
   name="$(basename "$script")"
   bashn_out="$(bash -n "$script" 2>&1)"
   if [ $? -eq 0 ]; then
@@ -128,9 +129,12 @@ done
 echo "== shellcheck（利用可能な場合のみ） =="
 
 if command -v shellcheck >/dev/null 2>&1; then
-  for script in "${REPO_ROOT}"/scripts/*.sh; do
+  # -x: sandbox-exec.sh は変数（${SCRIPT_DIR}）経由で scripts/lib/*.sh を source する。
+  # shellcheck はデフォルトでは変数経由の source 先を検証しない（SC1091）ため、
+  # severity を下げるのではなく -x で実際に解決させて検証の穴を作らないようにする。
+  for script in "${REPO_ROOT}"/scripts/*.sh "${REPO_ROOT}"/scripts/lib/*.sh; do
     name="$(basename "$script")"
-    shellcheck_out="$(shellcheck "$script" 2>&1)"
+    shellcheck_out="$(cd "$(dirname "$script")" && shellcheck -x "$(basename "$script")" 2>&1)"
     if [ $? -eq 0 ]; then
       pass "shellcheck: ${name}"
     else
@@ -318,6 +322,227 @@ fi
 CASE1_CACHE="$(plan_value cache_volume "$CASE1_OUTPUT")"
 CASE3_CACHE="$(plan_value cache_volume "$CASE3_OUTPUT")"
 assert_eq "ケース6: cache_volume はリポジトリ単位（worktree から叩いても同じ）" "$CASE1_CACHE" "$CASE3_CACHE"
+
+# ---------------------------------------------------------------------------
+# ケース7: container_belongs_to_repo（Docker 非依存の所属判定関数、Task #6）
+#
+# label あり／label なしの旧命名残骸／他リポジトリの3パターンを、docker を一切
+# 起動せずに純粋関数として直接検証する。
+# ---------------------------------------------------------------------------
+
+echo "== container_belongs_to_repo（所属判定・Docker 非依存） =="
+
+# shellcheck source=../scripts/lib/container-membership.sh
+. "${REPO_ROOT}/scripts/lib/container-membership.sh"
+
+HOST_ROOT_SAMPLE="/home/user/repo"
+
+if container_belongs_to_repo "myrepo" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  pass "label の repo が一致すれば対象に含まれる"
+else
+  fail "label の repo が一致すれば対象に含まれる"
+fi
+
+if container_belongs_to_repo "otherrepo" "${HOST_ROOT_SAMPLE}/anything" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  fail "label の repo が不一致なら対象に含まれない" "含まれてしまいました（マウント元が一致していても label 不一致を優先すべき）"
+else
+  pass "label の repo が不一致なら対象に含まれない"
+fi
+
+if container_belongs_to_repo "" "${HOST_ROOT_SAMPLE}/.claude/worktrees/agent-old" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  pass "label なし・マウント元がリポジトリルート配下なら対象に含まれる（旧命名の残骸回収）"
+else
+  fail "label なし・マウント元がリポジトリルート配下なら対象に含まれる"
+fi
+
+if container_belongs_to_repo "" "$HOST_ROOT_SAMPLE" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  pass "label なし・マウント元がリポジトリルート自身でも対象に含まれる"
+else
+  fail "label なし・マウント元がリポジトリルート自身でも対象に含まれる"
+fi
+
+if container_belongs_to_repo "" "/home/user/other-repo/subdir" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  fail "label なし・マウント元が別リポジトリなら対象に含まれない" "含まれてしまいました"
+else
+  pass "label なし・マウント元が別リポジトリなら対象に含まれない"
+fi
+
+if container_belongs_to_repo "" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  fail "label もマウント元も無ければ対象に含まれない" "含まれてしまいました"
+else
+  pass "label もマウント元も無ければ対象に含まれない"
+fi
+
+# ---------------------------------------------------------------------------
+# ケース8: --ls / --down --all（偽 docker で label・マウント元を注入し、実際の docker を起動せず検証する）
+#
+# 偽 docker は DW_TEST_MANIFEST（name|managed|repo|epic|image|status|created|mount_source
+# の '|' 区切り行）を読み、docker ps / docker container inspect / docker rm を模擬する。
+# `docker rm` は本物を一切呼ばず、DW_TEST_RM_LOG に対象名を追記するだけにする。
+# ---------------------------------------------------------------------------
+
+echo "== --ls / --down --all（偽 docker） =="
+
+LS_REPO="$(make_temp_repo)"
+copy_sandbox_scripts "$LS_REPO"
+
+LS_PLAN_OUTPUT="$(
+  cd "$LS_REPO" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan
+)"
+LS_REPO_BASENAME="$(basename "$LS_REPO")"
+LS_HOST_ROOT="$(plan_value repo_root "$LS_PLAN_OUTPUT")"
+
+DW_TEST_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/dw-test-manifest.XXXXXX")"
+DW_TEST_RM_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-rmlog.XXXXXX")"
+: > "$DW_TEST_RM_LOG"
+
+# 1) label ありで現リポジトリに属するコンテナ（現行の起動中コンテナを模す）
+# 2) label なしの旧命名残骸で、マウント元が現リポジトリのルート配下（回収されるべき）
+# 3) label ありで他リポジトリに属するコンテナ（--down --all の対象に含まれてはいけない）
+# 4) label なしで、マウント元が他リポジトリ配下（対象に含まれてはいけない）
+cat > "$DW_TEST_MANIFEST" <<MANIFEST
+dw-sandbox-${LS_REPO_BASENAME}|1|${LS_REPO_BASENAME}||dev-sandbox:${LS_REPO_BASENAME}|running|2024-01-01T00:00:00Z|${LS_HOST_ROOT}
+dw-sandbox-${LS_REPO_BASENAME}-legacy|||||exited|2023-01-01T00:00:00Z|${LS_HOST_ROOT}/.claude/worktrees/agent-old
+dw-sandbox-otherrepo|1|otherrepo||dev-sandbox:otherrepo|running|2024-02-02T00:00:00Z|/home/user/otherrepo
+dw-sandbox-otherrepo-legacy|||||exited|2023-03-03T00:00:00Z|/home/user/otherrepo/subdir
+MANIFEST
+
+FAKE_DOCKER_MANIFEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin-manifest.XXXXXX")"
+cat > "${FAKE_DOCKER_MANIFEST_DIR}/docker" <<'FAKE_DOCKER_MANIFEST'
+#!/bin/bash
+# tests/run-tests.sh 用の偽 docker（マニフェスト駆動）。ps / container inspect / rm のみ対応する。
+set -u
+MANIFEST="${DW_TEST_MANIFEST:?DW_TEST_MANIFEST is required}"
+
+manifest_line() {
+  awk -F'|' -v n="$1" '$1==n{print; exit}' "$MANIFEST"
+}
+
+case "${1:-}" in
+  ps)
+    shift
+    filter=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --filter) filter="$2"; shift 2 ;;
+        --format) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$filter" in
+      "label=dev-workflow.managed=1")
+        awk -F'|' '$2=="1"{print $1}' "$MANIFEST"
+        ;;
+      "name=dw-sandbox-")
+        awk -F'|' '$1 ~ /dw-sandbox-/{print $1}' "$MANIFEST"
+        ;;
+    esac
+    exit 0
+    ;;
+  container)
+    shift
+    [ "${1:-}" = "inspect" ] || exit 1
+    shift
+    tmpl=""
+    name=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -f) tmpl="$2"; shift 2 ;;
+        *) name="$1"; shift ;;
+      esac
+    done
+    line="$(manifest_line "$name")"
+    [ -n "$line" ] || exit 1
+    IFS='|' read -r f_name f_managed f_repo f_epic f_image f_status f_created f_mount <<< "$line"
+    case "$tmpl" in
+      *'dev-workflow.repo'*) printf '%s\n' "$f_repo" ;;
+      *'dev-workflow.epic'*) printf '%s\n' "$f_epic" ;;
+      *'Mounts'*)            printf '%s\n' "$f_mount" ;;
+      *'Config.Image'*)      printf '%s\n' "$f_image" ;;
+      *'State.Status'*)      printf '%s\n' "$f_status" ;;
+      *'Created'*)           printf '%s\n' "$f_created" ;;
+      *)                     printf '\n' ;;
+    esac
+    exit 0
+    ;;
+  rm)
+    shift
+    target=""
+    for a in "$@"; do
+      case "$a" in
+        -f) ;;
+        *) target="$a" ;;
+      esac
+    done
+    echo "$target" >> "${DW_TEST_RM_LOG:?DW_TEST_RM_LOG is required}"
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE_DOCKER_MANIFEST
+chmod +x "${FAKE_DOCKER_MANIFEST_DIR}/docker"
+
+# --- --ls: 他リポジトリの管理コンテナも含めて一覧表示する ---
+LS_OUTPUT="$(
+  cd "$LS_REPO" || exit 1
+  DW_TEST_MANIFEST="$DW_TEST_MANIFEST" PATH="${FAKE_DOCKER_MANIFEST_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --ls
+)"
+
+case "$LS_OUTPUT" in
+  *"dw-sandbox-${LS_REPO_BASENAME}"*"dw-sandbox-otherrepo"*|*"dw-sandbox-otherrepo"*"dw-sandbox-${LS_REPO_BASENAME}"*)
+    pass "--ls は自リポジトリと他リポジトリの管理コンテナを両方表示する"
+    ;;
+  *)
+    fail "--ls は自リポジトリと他リポジトリの管理コンテナを両方表示する" "output=[${LS_OUTPUT}]"
+    ;;
+esac
+
+if printf '%s\n' "$LS_OUTPUT" | grep -q "dw-sandbox-${LS_REPO_BASENAME}-legacy"; then
+  pass "--ls は label なしの旧命名残骸も表示する"
+else
+  fail "--ls は label なしの旧命名残骸も表示する" "output=[${LS_OUTPUT}]"
+fi
+
+# --- --down --all: 削除前に対象名を列挙し、自リポジトリ分のみ削除する ---
+: > "$DW_TEST_RM_LOG"
+DOWN_ALL_OUTPUT="$(
+  cd "$LS_REPO" || exit 1
+  DW_TEST_MANIFEST="$DW_TEST_MANIFEST" DW_TEST_RM_LOG="$DW_TEST_RM_LOG" \
+    PATH="${FAKE_DOCKER_MANIFEST_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --down --all
+)"
+
+if printf '%s\n' "$DOWN_ALL_OUTPUT" | grep -q "dw-sandbox-${LS_REPO_BASENAME}$"; then
+  pass "--down --all は削除前に label ありの自リポジトリコンテナ名を列挙する"
+else
+  fail "--down --all は削除前に label ありの自リポジトリコンテナ名を列挙する" "output=[${DOWN_ALL_OUTPUT}]"
+fi
+
+if printf '%s\n' "$DOWN_ALL_OUTPUT" | grep -q "dw-sandbox-${LS_REPO_BASENAME}-legacy"; then
+  pass "--down --all は削除前に label なしの旧命名残骸（マウント元一致）も列挙する"
+else
+  fail "--down --all は削除前に label なしの旧命名残骸（マウント元一致）も列挙する" "output=[${DOWN_ALL_OUTPUT}]"
+fi
+
+if printf '%s\n' "$DOWN_ALL_OUTPUT" | grep -q "otherrepo"; then
+  fail "--down --all は他リポジトリのコンテナを列挙しない" "output=[${DOWN_ALL_OUTPUT}]"
+else
+  pass "--down --all は他リポジトリのコンテナを列挙しない"
+fi
+
+RM_LOG_CONTENT="$(cat "$DW_TEST_RM_LOG")"
+RM_LOG_COUNT="$(printf '%s\n' "$RM_LOG_CONTENT" | grep -c . || true)"
+assert_eq "--down --all は自リポジトリ分の2件だけを docker rm する" "2" "$RM_LOG_COUNT"
+
+if printf '%s\n' "$RM_LOG_CONTENT" | grep -q "otherrepo"; then
+  fail "--down --all は他リポジトリのコンテナを削除しない" "rm_log=[${RM_LOG_CONTENT}]"
+else
+  pass "--down --all は他リポジトリのコンテナを削除しない"
+fi
 
 # ---------------------------------------------------------------------------
 # 結果集計

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -98,11 +98,29 @@ copy_sandbox_scripts() {
   cp "${REPO_ROOT}/scripts/sandbox-exec.sh"    "${dest}/scripts/sandbox-exec.sh"
   cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
   cp "${REPO_ROOT}/scripts/lib/container-membership.sh" "${dest}/scripts/lib/container-membership.sh"
+  cp "${REPO_ROOT}/scripts/lib/compose-conflicts.sh"    "${dest}/scripts/lib/compose-conflicts.sh"
   cp "${REPO_ROOT}/Dockerfile.dev"             "${dest}/Dockerfile.dev"
   (
     cd "$dest" || exit 1
     git add scripts Dockerfile.dev
     git commit -q -m "add sandbox scripts"
+  ) >/dev/null 2>&1
+}
+
+copy_sandbox_scripts_no_dockerfile() {
+  # copy_sandbox_scripts_no_dockerfile <dest_repo_dir>
+  # compose モード検証用。Dockerfile.dev を置かないことで resolve-sandbox.sh が
+  # compose モードを解決するようにする（Dockerfile.dev が優先されてしまうため）。
+  local dest="$1"
+  mkdir -p "${dest}/scripts/lib"
+  cp "${REPO_ROOT}/scripts/sandbox-exec.sh"    "${dest}/scripts/sandbox-exec.sh"
+  cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
+  cp "${REPO_ROOT}/scripts/lib/container-membership.sh" "${dest}/scripts/lib/container-membership.sh"
+  cp "${REPO_ROOT}/scripts/lib/compose-conflicts.sh"    "${dest}/scripts/lib/compose-conflicts.sh"
+  (
+    cd "$dest" || exit 1
+    git add scripts
+    git commit -q -m "add sandbox scripts (no dockerfile)"
   ) >/dev/null 2>&1
 }
 
@@ -993,6 +1011,342 @@ assert_eq "イメージID同一時: 既存コンテナを削除しない" "0" "$
 
 IMG_F_RUN_COUNT="$(grep -c '^run ' "$IMG_TEST_LOG" || true)"
 assert_eq "イメージID同一時: コンテナを作り直さない" "0" "$IMG_F_RUN_COUNT"
+
+# ---------------------------------------------------------------------------
+# ケース10: compose_conflict_warnings（Docker 非依存の衝突検出関数、Task #9）
+#
+# container_name / 固定ホストポートの検出を、docker を一切起動せずに純粋関数として
+# 直接検証する（Epic #3 仕様書 4.8）。
+# ---------------------------------------------------------------------------
+
+echo "== compose_conflict_warnings（衝突検出・Docker 非依存） =="
+
+# shellcheck source=../scripts/lib/compose-conflicts.sh
+. "${REPO_ROOT}/scripts/lib/compose-conflicts.sh"
+
+COMPOSE_CONFLICT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-compose-conflict.XXXXXX")"
+
+COMPOSE_FILE_CONTAINER_NAME="${COMPOSE_CONFLICT_DIR}/container-name.yml"
+cat > "$COMPOSE_FILE_CONTAINER_NAME" <<'YAML'
+services:
+  app:
+    build: .
+    container_name: myapp
+    volumes:
+      - .:/workspace
+YAML
+
+COMPOSE_FILE_FIXED_PORT="${COMPOSE_CONFLICT_DIR}/fixed-port.yml"
+cat > "$COMPOSE_FILE_FIXED_PORT" <<'YAML'
+services:
+  app:
+    build: .
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/workspace
+YAML
+
+COMPOSE_FILE_NO_CONFLICT="${COMPOSE_CONFLICT_DIR}/no-conflict.yml"
+cat > "$COMPOSE_FILE_NO_CONFLICT" <<'YAML'
+services:
+  app:
+    build: .
+    ports:
+      - "3000"
+    volumes:
+      - .:/workspace
+YAML
+
+CONTAINER_NAME_WARNINGS="$(compose_conflict_warnings "$COMPOSE_FILE_CONTAINER_NAME")"
+if [ -n "$CONTAINER_NAME_WARNINGS" ]; then
+  pass "container_name: を含む compose ファイルで警告が出る"
+else
+  fail "container_name: を含む compose ファイルで警告が出る" "警告が空でした"
+fi
+
+FIXED_PORT_WARNINGS="$(compose_conflict_warnings "$COMPOSE_FILE_FIXED_PORT")"
+if [ -n "$FIXED_PORT_WARNINGS" ]; then
+  pass "固定ホストポートを含む compose ファイルで警告が出る"
+else
+  fail "固定ホストポートを含む compose ファイルで警告が出る" "警告が空でした"
+fi
+
+NO_CONFLICT_WARNINGS="$(compose_conflict_warnings "$COMPOSE_FILE_NO_CONFLICT")"
+assert_eq "衝突が無い compose ファイル（コンテナ側ポートのみ）では警告が出ない" "" "$NO_CONFLICT_WARNINGS"
+
+# ---------------------------------------------------------------------------
+# ケース8: compose モードの compose_project / compose_file / compose_service / workdir
+# （Epic #3 仕様書「5. 検証方針」ケース8、Task #9）
+#
+# --project-directory がどの worktree から叩いてもリポジトリルートを指すこと、
+# -p に渡るプロジェクト名が worktree 名に依存しないことが本タスクの本丸。
+# ---------------------------------------------------------------------------
+
+echo "== compose モード（ケース8） =="
+
+COMPOSE_REPO="$(make_temp_repo)"
+copy_sandbox_scripts_no_dockerfile "$COMPOSE_REPO"
+
+COMPOSE_FILE_DEFAULT="${COMPOSE_REPO}/docker-compose.dev.yml"
+cat > "$COMPOSE_FILE_DEFAULT" <<'YAML'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/workspace
+YAML
+(
+  cd "$COMPOSE_REPO" || exit 1
+  git add docker-compose.dev.yml
+  git commit -q -m "add compose file"
+) >/dev/null 2>&1
+
+COMPOSE_REPO_BASENAME="$(basename "$COMPOSE_REPO")"
+
+# --- print-plan（リポジトリルートから） ---
+COMPOSE_CASE1_OUTPUT="$(print_plan_in "$COMPOSE_REPO")"
+
+assert_eq "compose: mode=compose" "compose" "$(plan_value mode "$COMPOSE_CASE1_OUTPUT")"
+assert_eq "compose: compose_file は docker-compose.dev.yml" "docker-compose.dev.yml" "$(plan_value compose_file "$COMPOSE_CASE1_OUTPUT")"
+assert_eq "compose: compose_service は既定値 app" "app" "$(plan_value compose_service "$COMPOSE_CASE1_OUTPUT")"
+assert_eq "compose: compose_project は dw-<repo>" "dw-${COMPOSE_REPO_BASENAME}" "$(plan_value compose_project "$COMPOSE_CASE1_OUTPUT")"
+assert_eq "compose: workdir はリポジトリルートで /workspace" "/workspace" "$(plan_value workdir "$COMPOSE_CASE1_OUTPUT")"
+
+# --- agent worktree から叩いても compose_project が worktree 名に依存しない（本タスクの本丸） ---
+COMPOSE_AGENT_WORKTREE_DIR="${COMPOSE_REPO}/.claude/worktrees/agent-x"
+make_worktree "$COMPOSE_REPO" "$COMPOSE_AGENT_WORKTREE_DIR" "compose-agent-worktree-branch"
+
+COMPOSE_CASE_AGENT_OUTPUT="$(print_plan_in "$COMPOSE_AGENT_WORKTREE_DIR")"
+
+assert_eq "compose: agent worktree からでも compose_project は同一（worktree 名非依存）" \
+  "$(plan_value compose_project "$COMPOSE_CASE1_OUTPUT")" "$(plan_value compose_project "$COMPOSE_CASE_AGENT_OUTPUT")"
+assert_eq "compose: agent worktree からの workdir は相対パス" \
+  "/workspace/.claude/worktrees/agent-x" "$(plan_value workdir "$COMPOSE_CASE_AGENT_OUTPUT")"
+
+# --- epic worktree からも compose_project が同一（agent worktree とも一致） ---
+COMPOSE_EPIC_WORKTREE_DIR="${COMPOSE_REPO}/.claude/worktrees/epic7"
+make_worktree "$COMPOSE_REPO" "$COMPOSE_EPIC_WORKTREE_DIR" "compose-epic-worktree-branch"
+
+COMPOSE_CASE_EPIC_OUTPUT="$(print_plan_in "$COMPOSE_EPIC_WORKTREE_DIR")"
+
+assert_eq "compose: epic worktree の compose_project も agent worktree と同一" \
+  "$(plan_value compose_project "$COMPOSE_CASE_AGENT_OUTPUT")" "$(plan_value compose_project "$COMPOSE_CASE_EPIC_OUTPUT")"
+
+# ---------------------------------------------------------------------------
+# compose モードの実行系（偽 docker で `docker compose` を模擬する）。
+#
+# 偽 docker は `compose -p PROJECT --project-directory DIR -f FILE <サブコマンド>...`
+# を解釈し、状態ファイルでサービスの running / not-running を切り替える。
+# 実際の docker には一切触れない。呼び出し引数は DW_COMPOSE_LOG にすべて記録する。
+# ---------------------------------------------------------------------------
+
+FAKE_DOCKER_COMPOSE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin-compose.XXXXXX")"
+cat > "${FAKE_DOCKER_COMPOSE_DIR}/docker" <<'FAKE_DOCKER_COMPOSE'
+#!/bin/bash
+# tests/run-tests.sh 用の偽 docker（compose モード専用）。実際の docker には一切触れない。
+set -u
+
+LOG="${DW_COMPOSE_LOG:?DW_COMPOSE_LOG is required}"
+STATE_FILE="${DW_COMPOSE_SERVICE_STATE:?DW_COMPOSE_SERVICE_STATE is required}"   # "" | running
+UP_SUCCEEDS="${DW_COMPOSE_UP_SUCCEEDS:-1}"
+WORKDIR_OK="${DW_COMPOSE_WORKDIR_OK:-1}"
+
+echo "$*" >> "$LOG"
+
+case "${1:-}" in
+  compose)
+    shift
+    # 先頭の共通オプション（-p / --project-directory / -f）を読み飛ばしてサブコマンドを取り出す
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -p|--project-directory|-f) shift 2 ;;
+        *) break ;;
+      esac
+    done
+    sub="${1:-}"
+    shift || true
+    case "$sub" in
+      ps)
+        state="$(cat "$STATE_FILE" 2>/dev/null || true)"
+        if [ "$state" = "running" ]; then
+          echo "fake-compose-container-id"
+        fi
+        exit 0
+        ;;
+      up)
+        if [ "$UP_SUCCEEDS" = "1" ]; then
+          printf 'running\n' > "$STATE_FILE"
+        fi
+        exit 0
+        ;;
+      exec)
+        case "$*" in
+          *"test -d"*)
+            [ "$WORKDIR_OK" = "1" ] && exit 0 || exit 1
+            ;;
+          *)
+            # -c の次の引数がコマンド文字列（quoting により1引数として渡ってくる）
+            cmd=""
+            prev=""
+            for a in "$@"; do
+              [ "$prev" = "-c" ] && cmd="$a"
+              prev="$a"
+            done
+            sh -c "$cmd"
+            exit $?
+            ;;
+        esac
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  container)
+    shift
+    [ "${1:-}" = "inspect" ] || exit 1
+    shift
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -f) shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    state="$(cat "$STATE_FILE" 2>/dev/null || true)"
+    if [ "$state" = "running" ]; then echo "true"; else echo "false"; fi
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE_DOCKER_COMPOSE
+chmod +x "${FAKE_DOCKER_COMPOSE_DIR}/docker"
+
+COMPOSE_TEST_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-composelog.XXXXXX")"
+COMPOSE_TEST_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-composestate.XXXXXX")"
+
+run_compose_case() {
+  # run_compose_case <dir> <initial_state> <up_succeeds 0/1> <workdir_ok 0/1> [追加のsandbox-exec.sh引数...]
+  local dir="$1" initial_state="$2" up_succeeds="$3" workdir_ok="$4"
+  shift 4
+
+  : > "$COMPOSE_TEST_LOG"
+  printf '%s' "$initial_state" > "$COMPOSE_TEST_STATE_FILE"
+
+  (
+    cd "$dir" || exit 1
+    DW_COMPOSE_LOG="$COMPOSE_TEST_LOG" \
+      DW_COMPOSE_SERVICE_STATE="$COMPOSE_TEST_STATE_FILE" \
+      DW_COMPOSE_UP_SUCCEEDS="$up_succeeds" \
+      DW_COMPOSE_WORKDIR_OK="$workdir_ok" \
+      PATH="${FAKE_DOCKER_COMPOSE_DIR}:${PATH}" \
+      bash scripts/sandbox-exec.sh "$@"
+  )
+}
+
+# --- agent worktree から叩いても --project-directory がリポジトリルートを指す（本タスクの本丸） ---
+COMPOSE_HOST_ROOT="$(plan_value repo_root "$COMPOSE_CASE1_OUTPUT")"
+
+COMPOSE_RUN1_EXIT=0
+run_compose_case "$COMPOSE_AGENT_WORKTREE_DIR" "running" 1 1 'true' >/dev/null 2>&1 || COMPOSE_RUN1_EXIT=$?
+assert_exit_code "compose: agent worktree からの実行が成功する" 0 "$COMPOSE_RUN1_EXIT"
+
+case "$(cat "$COMPOSE_TEST_LOG")" in
+  *"--project-directory ${COMPOSE_HOST_ROOT}"*)
+    pass "compose: agent worktree から叩いても --project-directory がリポジトリルートを指す" ;;
+  *)
+    fail "compose: agent worktree から叩いても --project-directory がリポジトリルートを指す" \
+      "log=[$(cat "$COMPOSE_TEST_LOG")] expected_root=[${COMPOSE_HOST_ROOT}]" ;;
+esac
+
+case "$(cat "$COMPOSE_TEST_LOG")" in
+  *"-p dw-${COMPOSE_REPO_BASENAME} "*)
+    pass "compose: -p に渡るプロジェクト名が agent worktree でも repo 基準" ;;
+  *)
+    fail "compose: -p に渡るプロジェクト名が agent worktree でも repo 基準" "log=[$(cat "$COMPOSE_TEST_LOG")]" ;;
+esac
+
+# --- サービス未起動時に up -d が呼ばれる ---
+COMPOSE_RUN2_EXIT=0
+run_compose_case "$COMPOSE_REPO" "" 1 1 'true' >/dev/null 2>&1 || COMPOSE_RUN2_EXIT=$?
+assert_exit_code "compose: サービス未起動から up -d 成功時は実行全体が成功する" 0 "$COMPOSE_RUN2_EXIT"
+
+if grep -q ' up -d app$' "$COMPOSE_TEST_LOG"; then
+  pass "compose: サービス未起動時に up -d が呼ばれる"
+else
+  fail "compose: サービス未起動時に up -d が呼ばれる" "log=[$(cat "$COMPOSE_TEST_LOG")]"
+fi
+
+# --- up -d しても起動しない場合、サービス名と DEV_WORKFLOW_COMPOSE_SERVICE を含むエラーで停止する ---
+COMPOSE_RUN3_STDERR="$(run_compose_case "$COMPOSE_REPO" "" 0 1 'true' 2>&1 1>/dev/null)"
+COMPOSE_RUN3_EXIT=$?
+
+if [ "$COMPOSE_RUN3_EXIT" -ne 0 ]; then
+  pass "compose: up -d しても起動しない場合は非0で終了する"
+else
+  fail "compose: up -d しても起動しない場合は非0で終了する" "exit=0"
+fi
+
+case "$COMPOSE_RUN3_STDERR" in
+  *"app"*) pass "compose: 起動失敗エラーにサービス名が含まれる" ;;
+  *) fail "compose: 起動失敗エラーにサービス名が含まれる" "stderr=[${COMPOSE_RUN3_STDERR}]" ;;
+esac
+
+case "$COMPOSE_RUN3_STDERR" in
+  *"DEV_WORKFLOW_COMPOSE_SERVICE"*) pass "compose: 起動失敗エラーに DEV_WORKFLOW_COMPOSE_SERVICE の案内が含まれる" ;;
+  *) fail "compose: 起動失敗エラーに DEV_WORKFLOW_COMPOSE_SERVICE の案内が含まれる" "stderr=[${COMPOSE_RUN3_STDERR}]" ;;
+esac
+
+# --- workdir が無い場合、DEV_WORKFLOW_COMPOSE_WORKDIR に言及したエラーで停止する ---
+COMPOSE_RUN4_STDERR="$(run_compose_case "$COMPOSE_REPO" "running" 1 0 'true' 2>&1 1>/dev/null)"
+COMPOSE_RUN4_EXIT=$?
+
+if [ "$COMPOSE_RUN4_EXIT" -ne 0 ]; then
+  pass "compose: workdir が無い場合は非0で終了する"
+else
+  fail "compose: workdir が無い場合は非0で終了する" "exit=0"
+fi
+
+case "$COMPOSE_RUN4_STDERR" in
+  *"DEV_WORKFLOW_COMPOSE_WORKDIR"*) pass "compose: workdir 不在エラーに DEV_WORKFLOW_COMPOSE_WORKDIR の案内が含まれる" ;;
+  *) fail "compose: workdir 不在エラーに DEV_WORKFLOW_COMPOSE_WORKDIR の案内が含まれる" "stderr=[${COMPOSE_RUN4_STDERR}]" ;;
+esac
+
+# --- container_name: を含む compose ファイルを使うと、実行時に stderr へ警告が出る（停止はしない） ---
+COMPOSE_WARN_REPO="$(make_temp_repo)"
+copy_sandbox_scripts_no_dockerfile "$COMPOSE_WARN_REPO"
+cat > "${COMPOSE_WARN_REPO}/docker-compose.dev.yml" <<'YAML'
+services:
+  app:
+    build: .
+    container_name: myapp
+    volumes:
+      - .:/workspace
+YAML
+(
+  cd "$COMPOSE_WARN_REPO" || exit 1
+  git add docker-compose.dev.yml
+  git commit -q -m "add compose file with container_name"
+) >/dev/null 2>&1
+
+COMPOSE_WARN_STDERR="$(
+  : > "$COMPOSE_TEST_LOG"
+  printf 'running' > "$COMPOSE_TEST_STATE_FILE"
+  cd "$COMPOSE_WARN_REPO" || exit 1
+  DW_COMPOSE_LOG="$COMPOSE_TEST_LOG" \
+    DW_COMPOSE_SERVICE_STATE="$COMPOSE_TEST_STATE_FILE" \
+    DW_COMPOSE_UP_SUCCEEDS=1 \
+    DW_COMPOSE_WORKDIR_OK=1 \
+    PATH="${FAKE_DOCKER_COMPOSE_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh 'true' 2>&1 1>/dev/null
+)"
+
+case "$COMPOSE_WARN_STDERR" in
+  *"container_name"*) pass "compose: 実行時に container_name の衝突警告が stderr に出る" ;;
+  *) fail "compose: 実行時に container_name の衝突警告が stderr に出る" "stderr=[${COMPOSE_WARN_STDERR}]" ;;
+esac
 
 # ---------------------------------------------------------------------------
 # 結果集計

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1475,6 +1475,153 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# check-readability.sh の非対話ハング修正（Task #10、Epic #3 仕様書 4.9）
+#
+# `--git` / `--staged` / ファイル引数が1つでもあれば stdin を一切読まない。
+# 引数なし・非ttyのフック経路だけ上限付きで読み、タイムアウト時は exit 0 で
+# 素通りする。ガード本体の判定ロジック（base64ブロブ検出・長い行検出）は
+# 変更しない仕様のため、違反検出が従来どおり働くこともあわせて検証する。
+#
+# 「stdinを読まない」ことの検証は、プロセス置換 `< <(sleep N)` で終端しない
+# stdinを用意して行う。パイプ（`sleep N | cmd`）だと親シェルが sleep の終了まで
+# 待たされてテストが遅くなるが、プロセス置換なら判定対象コマンドが先に終われば
+# 親シェルはバックグラウンドの sleep を待たない。もしスクリプトが誤って stdin を
+# 読もうとした場合だけ `timeout` に引っかかり、それを失敗として検出する。
+# ---------------------------------------------------------------------------
+
+echo "== check-readability.sh（非対話ハング修正・Task #10） =="
+
+CHECK_READABILITY_SCRIPT="${REPO_ROOT}/scripts/check-readability.sh"
+
+RG_TMP_REPO="$(make_temp_repo)"
+RG_CLEAN_FILE="clean.txt"
+(
+  cd "$RG_TMP_REPO" || exit 1
+  printf 'clean file\n' > "$RG_CLEAN_FILE"
+) >/dev/null 2>&1
+
+# --- --git はstdinが開いたままでもハングせず即座に返る ---
+RG_GIT_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  timeout 5 bash "$CHECK_READABILITY_SCRIPT" --git < <(sleep 10) >/dev/null 2>&1
+)
+RG_GIT_EXIT=$?
+assert_exit_code "--git はstdinが開いたままでもハングせず即座に返る" 0 "$RG_GIT_EXIT"
+
+# --- ファイル引数を渡した場合もstdinを読まない ---
+RG_FILEARG_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  timeout 5 bash "$CHECK_READABILITY_SCRIPT" "$RG_CLEAN_FILE" < <(sleep 10) >/dev/null 2>&1
+)
+RG_FILEARG_EXIT=$?
+assert_exit_code "ファイル引数を渡した場合もstdinを読まず即座に返る" 0 "$RG_FILEARG_EXIT"
+
+# --- --staged も同様 ---
+(
+  cd "$RG_TMP_REPO" || exit 1
+  git add "$RG_CLEAN_FILE"
+) >/dev/null 2>&1
+
+RG_STAGED_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  timeout 5 bash "$CHECK_READABILITY_SCRIPT" --staged < <(sleep 10) >/dev/null 2>&1
+)
+RG_STAGED_EXIT=$?
+assert_exit_code "--stagedもstdinが開いたままでもハングせず即座に返る" 0 "$RG_STAGED_EXIT"
+
+# --- 引数なし・非ttyで入力が来ない場合、タイムアウト後にexit 0で素通りする ---
+# テストを遅くしないよう READABILITY_STDIN_TIMEOUT=1 で短くする。
+RG_TIMEOUT_STDERR="$(mktemp "${TMPDIR:-/tmp}/dw-test-rg-timeout-stderr.XXXXXX")"
+RG_TIMEOUT_EXIT=0
+timeout 5 env READABILITY_STDIN_TIMEOUT=1 bash "$CHECK_READABILITY_SCRIPT" \
+  < <(sleep 10) >/dev/null 2>"$RG_TIMEOUT_STDERR"
+RG_TIMEOUT_EXIT=$?
+assert_exit_code "引数なし・非ttyで入力が来ない場合はタイムアウト後exit 0で素通りする" 0 "$RG_TIMEOUT_EXIT"
+
+if grep -q "1秒" "$RG_TIMEOUT_STDERR"; then
+  pass "タイムアウト時にREADABILITY_STDIN_TIMEOUTの秒数を含む警告がstderrに出る"
+else
+  fail "タイムアウト時にREADABILITY_STDIN_TIMEOUTの秒数を含む警告がstderrに出る" "stderr=[$(cat "$RG_TIMEOUT_STDERR")]"
+fi
+
+# --- 引数なし・非ttyでフックJSONが渡された場合は従来どおり処理される（クリーンなファイル） ---
+RG_HOOK_CLEAN_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  printf '{"tool_input":{"file_path":"%s"}}' "$RG_CLEAN_FILE" | bash "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG_HOOK_CLEAN_EXIT=$?
+assert_exit_code "フックJSONのfile_pathから抽出したクリーンなファイルはexit 0" 0 "$RG_HOOK_CLEAN_EXIT"
+
+# --- 引数なし・非ttyでフックJSONが渡された場合は従来どおり処理される（違反ファイル） ---
+RG_VIOLATION_FILE="violation.txt"
+(
+  cd "$RG_TMP_REPO" || exit 1
+  head -c 3000 /dev/zero | tr '\0' 'A' > "$RG_VIOLATION_FILE"
+) >/dev/null 2>&1
+
+RG_HOOK_VIOLATION_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  printf '{"tool_input":{"file_path":"%s"}}' "$RG_VIOLATION_FILE" \
+    | READABILITY_MAX_BASE64=50 bash "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG_HOOK_VIOLATION_EXIT=$?
+assert_exit_code "フックJSON経由でも違反ファイルはブロックされる" 2 "$RG_HOOK_VIOLATION_EXIT"
+
+# --- 違反検出ロジックは従来どおり働く（巨大なbase64ブロブ） ---
+RG_BLOB_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  READABILITY_MAX_BASE64=50 bash "$CHECK_READABILITY_SCRIPT" "$RG_VIOLATION_FILE" >/dev/null 2>&1
+)
+RG_BLOB_EXIT=$?
+assert_exit_code "巨大なbase64ブロブを含むファイルはexit 2" 2 "$RG_BLOB_EXIT"
+
+# --- 違反検出ロジックは従来どおり働く（極端に長い行）。
+# base64文字集合に含まれない '-' で埋めることで、base64ブロブ検出とは
+# 独立に「長い行」ルール単体の検出を確認する。
+RG_LONGLINE_FILE="longline.txt"
+(
+  cd "$RG_TMP_REPO" || exit 1
+  head -c 6000 /dev/zero | tr '\0' '-' > "$RG_LONGLINE_FILE"
+  printf '\n' >> "$RG_LONGLINE_FILE"
+) >/dev/null 2>&1
+
+RG_LONGLINE_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  bash "$CHECK_READABILITY_SCRIPT" "$RG_LONGLINE_FILE" >/dev/null 2>&1
+)
+RG_LONGLINE_EXIT=$?
+assert_exit_code "極端に長い行を含むファイルはexit 2" 2 "$RG_LONGLINE_EXIT"
+
+# --- クリーンなファイルはexit 0（引数指定） ---
+RG_CLEAN_EXIT=0
+(
+  cd "$RG_TMP_REPO" || exit 1
+  bash "$CHECK_READABILITY_SCRIPT" "$RG_CLEAN_FILE" >/dev/null 2>&1
+)
+RG_CLEAN_EXIT=$?
+assert_exit_code "クリーンなファイルはexit 0" 0 "$RG_CLEAN_EXIT"
+
+# --- ヘッダコメントに実在しない --exit-code の記述が残っていない ---
+if grep -q -- '--exit-code' "$CHECK_READABILITY_SCRIPT"; then
+  fail "ヘッダコメントに実在しない--exit-codeの記述が残っていない" "grep hit: $(grep -n -- '--exit-code' "$CHECK_READABILITY_SCRIPT")"
+else
+  pass "ヘッダコメントに実在しない--exit-codeの記述が残っていない"
+fi
+
+if grep -q "DEV_WORKFLOW_HOOK_VENDOR=exit-code" "$CHECK_READABILITY_SCRIPT"; then
+  pass "ヘッダコメントがDEV_WORKFLOW_HOOK_VENDOR=exit-codeの正しい説明に修正されている"
+else
+  fail "ヘッダコメントがDEV_WORKFLOW_HOOK_VENDOR=exit-codeの正しい説明に修正されている" "grepで見つかりませんでした"
+fi
+
+# ---------------------------------------------------------------------------
 # 結果集計
 # ---------------------------------------------------------------------------
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -411,7 +411,7 @@ MANIFEST
 FAKE_DOCKER_MANIFEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin-manifest.XXXXXX")"
 cat > "${FAKE_DOCKER_MANIFEST_DIR}/docker" <<'FAKE_DOCKER_MANIFEST'
 #!/bin/bash
-# tests/run-tests.sh 用の偽 docker（マニフェスト駆動）。ps / container inspect / rm のみ対応する。
+# tests/run-tests.sh 用の偽 docker（マニフェスト駆動）。ps / container inspect / rm / volume rm に対応する。
 set -u
 MANIFEST="${DW_TEST_MANIFEST:?DW_TEST_MANIFEST is required}"
 
@@ -461,6 +461,9 @@ case "${1:-}" in
       *'Mounts'*)            printf '%s\n' "$f_mount" ;;
       *'Config.Image'*)      printf '%s\n' "$f_image" ;;
       *'State.Status'*)      printf '%s\n' "$f_status" ;;
+      *'State.Running'*)
+        if [ "$f_status" = "running" ]; then printf 'true\n'; else printf 'false\n'; fi
+        ;;
       *'Created'*)           printf '%s\n' "$f_created" ;;
       *)                     printf '\n' ;;
     esac
@@ -476,6 +479,15 @@ case "${1:-}" in
       esac
     done
     echo "$target" >> "${DW_TEST_RM_LOG:?DW_TEST_RM_LOG is required}"
+    exit 0
+    ;;
+  volume)
+    shift
+    [ "${1:-}" = "rm" ] || exit 1
+    shift
+    for a in "$@"; do
+      echo "$a" >> "${DW_TEST_VOLUME_RM_LOG:?DW_TEST_VOLUME_RM_LOG is required}"
+    done
     exit 0
     ;;
   *)
@@ -543,6 +555,126 @@ if printf '%s\n' "$RM_LOG_CONTENT" | grep -q "otherrepo"; then
 else
   pass "--down --all は他リポジトリのコンテナを削除しない"
 fi
+
+# ---------------------------------------------------------------------------
+# ケース9: --reset-cache のガード（列挙・running 検出・--force。Task #7、Epic #3 仕様書 4.6）
+#
+# キャッシュ volume はリポジトリ単位で共有するため、running 判定は現在の epic だけでなく
+# 同一リポジトリの管理コンテナ全体（他 epic のものも含む）を対象にする。--ls / --down --all
+# と同じ偽 docker（マニフェスト駆動、State.Running / volume rm に対応済み）を再利用する。
+# ---------------------------------------------------------------------------
+
+echo "== --reset-cache（列挙・running 検出・--force。Task #7） =="
+
+RESET_REPO="$(make_temp_repo)"
+copy_sandbox_scripts "$RESET_REPO"
+
+RESET_PLAN_OUTPUT="$(
+  cd "$RESET_REPO" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan
+)"
+RESET_REPO_BASENAME="$(basename "$RESET_REPO")"
+RESET_HOST_ROOT="$(plan_value repo_root "$RESET_PLAN_OUTPUT")"
+RESET_CACHE_VOLUME_COUNT="$(printf '%s\n' "$RESET_PLAN_OUTPUT" | grep -c '^cache_volume=')"
+
+DW_TEST_VOLUME_RM_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-volrmlog.XXXXXX")"
+: > "$DW_TEST_VOLUME_RM_LOG"
+
+run_reset_cache() {
+  # run_reset_cache <manifest内容> [追加の引数...]
+  local manifest_body="$1"
+  shift
+  printf '%s\n' "$manifest_body" > "$DW_TEST_MANIFEST"
+  : > "$DW_TEST_RM_LOG"
+  : > "$DW_TEST_VOLUME_RM_LOG"
+  (
+    cd "$RESET_REPO" || exit 1
+    DW_TEST_MANIFEST="$DW_TEST_MANIFEST" DW_TEST_RM_LOG="$DW_TEST_RM_LOG" \
+      DW_TEST_VOLUME_RM_LOG="$DW_TEST_VOLUME_RM_LOG" \
+      PATH="${FAKE_DOCKER_MANIFEST_DIR}:${PATH}" \
+      bash scripts/sandbox-exec.sh --reset-cache "$@"
+  )
+}
+
+# --- 常に: 削除対象 volume がすべて列挙表示される（実行結果の成否によらない） ---
+NOT_RUNNING_MANIFEST="dw-sandbox-${RESET_REPO_BASENAME}-epicA|1|${RESET_REPO_BASENAME}|epicA|dev-sandbox:${RESET_REPO_BASENAME}|exited|2024-01-01T00:00:00Z|${RESET_HOST_ROOT}"
+
+RESET_ENUM_OUTPUT="$(run_reset_cache "$NOT_RUNNING_MANIFEST" 2>&1)"
+NOT_RUNNING_EXIT=$?
+RESET_ENUM_LISTED_COUNT="$(printf '%s\n' "$RESET_ENUM_OUTPUT" | grep -c '^  - dw-cache-')"
+assert_eq "--reset-cache は削除対象 volume をすべて列挙表示する" "$RESET_CACHE_VOLUME_COUNT" "$RESET_ENUM_LISTED_COUNT"
+
+# --- 同一リポジトリのコンテナが running でないときは --force なしでも実行される ---
+if [ "$NOT_RUNNING_EXIT" -eq 0 ]; then
+  pass "同一リポジトリのコンテナが running でないとき --force なしでも成功する"
+else
+  fail "同一リポジトリのコンテナが running でないとき --force なしでも成功する" "exit=${NOT_RUNNING_EXIT}"
+fi
+
+VOL_RM_COUNT="$(grep -c . "$DW_TEST_VOLUME_RM_LOG" || true)"
+assert_eq "running でないとき docker volume rm が volume 数だけ呼ばれる" "$RESET_CACHE_VOLUME_COUNT" "$VOL_RM_COUNT"
+
+# --- 同一リポジトリの管理コンテナ（他 epic）が running なら --force なしでは中断する ---
+RUNNING_OWN_REPO_MANIFEST="dw-sandbox-${RESET_REPO_BASENAME}-epicA|1|${RESET_REPO_BASENAME}|epicA|dev-sandbox:${RESET_REPO_BASENAME}|running|2024-01-01T00:00:00Z|${RESET_HOST_ROOT}"
+
+RESET_BLOCK_STDERR="$(run_reset_cache "$RUNNING_OWN_REPO_MANIFEST" 2>&1 1>/dev/null)"
+RESET_BLOCK_EXIT=$?
+
+if [ "$RESET_BLOCK_EXIT" -ne 0 ]; then
+  pass "同一リポジトリの他 epic コンテナが running なら --force なしでは非0で終了する"
+else
+  fail "同一リポジトリの他 epic コンテナが running なら --force なしでは非0で終了する" "exit=0"
+fi
+
+VOL_RM_COUNT_BLOCKED="$(grep -c . "$DW_TEST_VOLUME_RM_LOG" || true)"
+assert_eq "running のとき --force なしでは docker volume rm を呼ばない" "0" "$VOL_RM_COUNT_BLOCKED"
+
+case "$RESET_BLOCK_STDERR" in
+  *"dw-sandbox-${RESET_REPO_BASENAME}-epicA"*) pass "中断メッセージに running なコンテナ名が含まれる" ;;
+  *) fail "中断メッセージに running なコンテナ名が含まれる" "stderr=[${RESET_BLOCK_STDERR}]" ;;
+esac
+
+case "$RESET_BLOCK_STDERR" in
+  *"--force"*) pass "中断メッセージに --force の案内が含まれる" ;;
+  *) fail "中断メッセージに --force の案内が含まれる" "stderr=[${RESET_BLOCK_STDERR}]" ;;
+esac
+
+# --- --force 指定時は running でも実行される ---
+RESET_FORCE_EXIT_OUTPUT="$(run_reset_cache "$RUNNING_OWN_REPO_MANIFEST" --force 2>&1)"
+RESET_FORCE_EXIT=$?
+
+if [ "$RESET_FORCE_EXIT" -eq 0 ]; then
+  pass "--force 指定時は running でも成功する"
+else
+  fail "--force 指定時は running でも成功する" "exit=${RESET_FORCE_EXIT} output=[${RESET_FORCE_EXIT_OUTPUT}]"
+fi
+
+VOL_RM_COUNT_FORCED="$(grep -c . "$DW_TEST_VOLUME_RM_LOG" || true)"
+assert_eq "--force 指定時は docker volume rm が volume 数だけ呼ばれる" "$RESET_CACHE_VOLUME_COUNT" "$VOL_RM_COUNT_FORCED"
+
+# --- 別リポジトリのコンテナが running でも中断しない（誤って巻き込まない） ---
+OTHER_REPO_RUNNING_MANIFEST="dw-sandbox-otherrepo|1|otherrepo||dev-sandbox:otherrepo|running|2024-02-02T00:00:00Z|/home/user/otherrepo"
+
+RESET_OTHER_REPO_OUTPUT="$(run_reset_cache "$OTHER_REPO_RUNNING_MANIFEST" 2>&1)"
+RESET_OTHER_REPO_EXIT=$?
+
+if [ "$RESET_OTHER_REPO_EXIT" -eq 0 ]; then
+  pass "別リポジトリのコンテナが running でも中断しない"
+else
+  fail "別リポジトリのコンテナが running でも中断しない" "exit=${RESET_OTHER_REPO_EXIT} output=[${RESET_OTHER_REPO_OUTPUT}]"
+fi
+
+# --- ヘルプに作用範囲（リポジトリ全体）の記載がある ---
+SANDBOX_EXEC_HEADER="$(sed -n '1,25p' "${REPO_ROOT}/scripts/sandbox-exec.sh")"
+case "$SANDBOX_EXEC_HEADER" in
+  *"リポジトリ全体"*) pass "ヘッダコメントに --reset-cache の作用範囲（リポジトリ全体）の記載がある" ;;
+  *) fail "ヘッダコメントに --reset-cache の作用範囲（リポジトリ全体）の記載がある" "header=[${SANDBOX_EXEC_HEADER}]" ;;
+esac
+
+case "$RESET_BLOCK_STDERR" in
+  *"リポジトリ全体"*) pass "中断メッセージにも作用範囲（リポジトリ全体）の記載がある" ;;
+  *) fail "中断メッセージにも作用範囲（リポジトリ全体）の記載がある" "stderr=[${RESET_BLOCK_STDERR}]" ;;
+esac
 
 # ---------------------------------------------------------------------------
 # 結果集計

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -2475,6 +2475,154 @@ assert_exit_code "compose: docker ps の列挙に失敗しても --ls 自体は�
   0 "$COMPOSE_PS_FAIL_EXIT"
 
 # ---------------------------------------------------------------------------
+# check-readability.sh: 外部 `timeout` コマンドへの非依存化（回帰防止 #35・レビュー2巡目）
+#
+# #31 の修正で stdin 読み取りを `timeout "$secs" cat` に丸ごと委譲するようになったが、
+# `timeout` は GNU coreutils / BusyBox のコマンドで macOS の既定環境には無い
+# （`gtimeout` のみ）。command not found（status 127）を「入力が来なかった」と
+# 誤判定し、macOS では可読性ガードの PostToolUse フック経路が常時無効化されて
+# いた（#31 が問題視した「入力形式の差でガードが黙って無効化される」のと
+# 同じ事故が環境の差で再現していた）。
+#
+# 修正後は bash 組み込みの `read -t` だけで複数行を読み切り、外部コマンドに
+# 依存しない。ここでは
+#   1) 末尾に改行の無い入力でも最終行（file_path）を取りこぼさないこと
+#   2) PATH から timeout/gtimeout を完全に排除した環境でも、複数行JSONの
+#      違反検出・クリーン判定・タイムアウト・--gitのハング防止が
+#      引き続き機能すること
+# を確認する。
+# ---------------------------------------------------------------------------
+
+echo "== check-readability.sh（外部timeoutコマンドへの非依存化・回帰防止 #35） =="
+
+RG35_TMP_REPO="$(make_temp_repo)"
+RG35_VIOLATION_FILE="violation.txt"
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  head -c 3000 /dev/zero | tr '\0' 'A' > "$RG35_VIOLATION_FILE"
+) >/dev/null 2>&1
+
+# --- 末尾に改行の無いフックJSONでも最終行(file_path)を取りこぼさず違反を検出する ---
+RG35_NO_TRAILING_NEWLINE_JSON="$(printf '{\n  "tool_input": {\n    "file_path": "%s"\n  }\n}' "$RG35_VIOLATION_FILE")"
+
+# 検証用入力の末尾に改行が無いこと自体を前提として固定しておく
+case "$RG35_NO_TRAILING_NEWLINE_JSON" in
+  *$'\n') fail "検証用入力の末尾に改行が無い（前提）" "末尾に改行がありました" ;;
+  *) pass "検証用入力の末尾に改行が無い（前提）" ;;
+esac
+
+RG35_NO_TRAILING_NEWLINE_EXIT=0
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  printf '%s' "$RG35_NO_TRAILING_NEWLINE_JSON" \
+    | READABILITY_MAX_BASE64=50 bash "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG35_NO_TRAILING_NEWLINE_EXIT=$?
+assert_exit_code "末尾に改行の無いフックJSONでも最終行(file_path)を取りこぼさず違反を検出する" 2 "$RG35_NO_TRAILING_NEWLINE_EXIT"
+
+# --- PATHから timeout/gtimeout を排除した環境を構築する ---
+# 特定のディレクトリを丸ごとPATHから外すと、同じディレクトリに同居する
+# grep/sed/awk/git 等の必須コマンドまで失われてしまうため、ファイル名単位で
+# timeout/gtimeout だけを除外したシンボリックリンク集を新設のディレクトリに作る。
+build_path_without_timeout() {
+  local dest="$1"
+  local IFS=':'
+  local p f b
+  for p in $PATH; do
+    [ -n "$p" ] && [ -d "$p" ] || continue
+    for f in "$p"/*; do
+      [ -e "$f" ] || continue
+      b="$(basename "$f")"
+      case "$b" in
+        timeout|gtimeout) continue ;;
+      esac
+      [ -e "${dest}/${b}" ] || ln -sf "$f" "${dest}/${b}" 2>/dev/null
+    done
+  done
+}
+
+RG35_NOTIMEOUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-notimeout-bin.XXXXXX")"
+build_path_without_timeout "$RG35_NOTIMEOUT_DIR"
+RG35_BASH_BIN="$(command -v bash)"
+
+# 構築したPATHに timeout/gtimeout が存在しないこと自体を前提として固定しておく
+# （この前提が崩れていたら以降のテストは無意味なので、まず単独で確認する）。
+if PATH="$RG35_NOTIMEOUT_DIR" command -v timeout >/dev/null 2>&1 \
+  || PATH="$RG35_NOTIMEOUT_DIR" command -v gtimeout >/dev/null 2>&1; then
+  fail "検証用PATHにtimeout/gtimeoutが存在しない（前提）" "timeoutまたはgtimeoutが見つかりました"
+else
+  pass "検証用PATHにtimeout/gtimeoutが存在しない（前提）"
+fi
+
+# --- timeoutコマンドがPATHに無くても、複数行に整形されたフックJSONの違反を検出できる ---
+RG35_MULTILINE_JSON=$(cat <<EOF
+{
+  "session_id": "abc123",
+  "tool_input": {
+    "file_path": "${RG35_VIOLATION_FILE}"
+  },
+  "tool_name": "Write"
+}
+EOF
+)
+
+RG35_MULTILINE_EXIT=0
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  printf '%s' "$RG35_MULTILINE_JSON" \
+    | PATH="$RG35_NOTIMEOUT_DIR" READABILITY_MAX_BASE64=50 "$RG35_BASH_BIN" "$CHECK_READABILITY_SCRIPT" \
+      >/dev/null 2>&1
+)
+RG35_MULTILINE_EXIT=$?
+assert_exit_code "timeoutコマンドがPATHに無くても複数行JSONの違反を検出する" 2 "$RG35_MULTILINE_EXIT"
+
+# --- timeoutコマンドがPATHに無くても、クリーンなファイルはexit 0（誤検出しない） ---
+RG35_CLEAN_FILE="clean-notimeout.txt"
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  printf 'clean file\n' > "$RG35_CLEAN_FILE"
+) >/dev/null 2>&1
+
+RG35_CLEAN_JSON=$(cat <<EOF
+{
+  "tool_input": {
+    "file_path": "${RG35_CLEAN_FILE}"
+  }
+}
+EOF
+)
+
+RG35_CLEAN_EXIT=0
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  printf '%s' "$RG35_CLEAN_JSON" \
+    | PATH="$RG35_NOTIMEOUT_DIR" "$RG35_BASH_BIN" "$CHECK_READABILITY_SCRIPT" >/dev/null 2>&1
+)
+RG35_CLEAN_EXIT=$?
+assert_exit_code "timeoutコマンドがPATHに無くてもクリーンなファイルはexit 0（誤検出しない）" 0 "$RG35_CLEAN_EXIT"
+
+# --- timeoutコマンドがPATHに無くても、入力が来ない場合はハングせずタイムアウトしてexit 0 ---
+RG35_NOINPUT_EXIT=0
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  timeout 8 env READABILITY_STDIN_TIMEOUT=1 PATH="$RG35_NOTIMEOUT_DIR" "$RG35_BASH_BIN" \
+    "$CHECK_READABILITY_SCRIPT" < <(sleep 30) >/dev/null 2>&1
+)
+RG35_NOINPUT_EXIT=$?
+assert_exit_code "timeoutコマンドがPATHに無くても、入力が来ない場合はハングせずタイムアウトしてexit 0で素通りする" \
+  0 "$RG35_NOINPUT_EXIT"
+
+# --- timeoutコマンドがPATHに無くても、stdinを開いたまま--gitを叩けば即座に返る（ハング再発なし） ---
+RG35_GIT_HANG_EXIT=0
+(
+  cd "$RG35_TMP_REPO" || exit 1
+  timeout 8 env PATH="$RG35_NOTIMEOUT_DIR" "$RG35_BASH_BIN" "$CHECK_READABILITY_SCRIPT" --git \
+    < <(sleep 30) >/dev/null 2>&1
+)
+RG35_GIT_HANG_EXIT=$?
+assert_exit_code "timeoutコマンドがPATHに無くても、stdinを開いたまま--gitを叩けば即座に返る" 0 "$RG35_GIT_HANG_EXIT"
+
+# ---------------------------------------------------------------------------
 # 結果集計
 # ---------------------------------------------------------------------------
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -97,6 +97,7 @@ copy_sandbox_scripts() {
   mkdir -p "${dest}/scripts/lib"
   cp "${REPO_ROOT}/scripts/sandbox-exec.sh"    "${dest}/scripts/sandbox-exec.sh"
   cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
+  cp "${REPO_ROOT}/scripts/lib/mount-path.sh"           "${dest}/scripts/lib/mount-path.sh"
   cp "${REPO_ROOT}/scripts/lib/container-membership.sh" "${dest}/scripts/lib/container-membership.sh"
   cp "${REPO_ROOT}/scripts/lib/compose-conflicts.sh"    "${dest}/scripts/lib/compose-conflicts.sh"
   cp "${REPO_ROOT}/Dockerfile.dev"             "${dest}/Dockerfile.dev"
@@ -115,6 +116,7 @@ copy_sandbox_scripts_no_dockerfile() {
   mkdir -p "${dest}/scripts/lib"
   cp "${REPO_ROOT}/scripts/sandbox-exec.sh"    "${dest}/scripts/sandbox-exec.sh"
   cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
+  cp "${REPO_ROOT}/scripts/lib/mount-path.sh"           "${dest}/scripts/lib/mount-path.sh"
   cp "${REPO_ROOT}/scripts/lib/container-membership.sh" "${dest}/scripts/lib/container-membership.sh"
   cp "${REPO_ROOT}/scripts/lib/compose-conflicts.sh"    "${dest}/scripts/lib/compose-conflicts.sh"
   (
@@ -273,6 +275,32 @@ else
   pass "--epic 付き --print-plan も docker を起動しない"
 fi
 
+# --- --epic に値が無いまま渡された場合は無限ループせず明快なエラーで停止する ---
+# shift 2 が失敗して $# が減らないまま while ループが回り続ける不具合があった
+# （実測: timeout 8 bash scripts/sandbox-exec.sh --epic は exit 124 だった）。
+if command -v timeout >/dev/null 2>&1; then
+  EPIC_NO_VALUE_STDERR="$(
+    cd "$PRINT_PLAN_REPO" || exit 1
+    PATH="${FAKE_BIN_DIR}:${PATH}" timeout 8 bash scripts/sandbox-exec.sh --epic 2>&1 1>/dev/null
+  )"
+  EPIC_NO_VALUE_EXIT=$?
+
+  if [ "$EPIC_NO_VALUE_EXIT" -eq 124 ]; then
+    fail "--epic に値が無い場合は無限ループしない" "timeout（exit 124）で停止しました"
+  elif [ "$EPIC_NO_VALUE_EXIT" -eq 0 ]; then
+    fail "--epic に値が無い場合は非0で終了する" "exit=0"
+  else
+    pass "--epic に値が無い場合は無限ループせず非0で終了する"
+  fi
+
+  case "$EPIC_NO_VALUE_STDERR" in
+    *"--epic"*) pass "--epic に値が無い場合のエラーに --epic の記載がある" ;;
+    *) fail "--epic に値が無い場合のエラーに --epic の記載がある" "stderr=[${EPIC_NO_VALUE_STDERR}]" ;;
+  esac
+else
+  skip "--epic に値が無い場合は無限ループせず明快なエラーで停止する" "timeout コマンドが利用できません"
+fi
+
 # ---------------------------------------------------------------------------
 # ケース1〜6: パス解決とコンテナ名の一致（Epic #3 仕様書「5. 検証方針」のケース1〜6、Task #5）
 #
@@ -366,10 +394,51 @@ CASE3_CACHE="$(plan_value cache_volume "$CASE3_OUTPUT")"
 assert_eq "ケース6: cache_volume はリポジトリ単位（worktree から叩いても同じ）" "$CASE1_CACHE" "$CASE3_CACHE"
 
 # ---------------------------------------------------------------------------
-# ケース7: container_belongs_to_repo（Docker 非依存の所属判定関数、Task #6）
+# ケース7a: normalize_mount_source（Docker 非依存の純粋関数、issue #25）
 #
-# label あり／label なしの旧命名残骸／他リポジトリの3パターンを、docker を一切
+# Windows + Docker Desktop の bind mount .Source（/run/desktop/mnt/host/<drive>/...）と
+# pwd -W によるホスト側パス（<DRIVE>:/...）を、大小文字・区切りを揃えた同一表現に
+# 正規化できることを、docker を一切起動せずに直接検証する。
+# ---------------------------------------------------------------------------
+
+echo "== normalize_mount_source（マウント元の正規化・Docker 非依存・issue #25） =="
+
+# shellcheck source=../scripts/lib/mount-path.sh
+. "${REPO_ROOT}/scripts/lib/mount-path.sh"
+
+assert_eq "normalize_mount_source: Docker Desktop 形式 (/run/desktop/mnt/host/<drive>/...) を <DRIVE>:/... へ変換する" \
+  "C:/users/mimay/documents/github/dev-workflow" \
+  "$(normalize_mount_source "/run/desktop/mnt/host/c/Users/mimay/Documents/github/dev-workflow")"
+
+assert_eq "normalize_mount_source: pwd -W 形式（既に <DRIVE>:/...）も同じ表現に正規化する" \
+  "C:/users/mimay/documents/github/dev-workflow" \
+  "$(normalize_mount_source "C:/Users/mimay/Documents/github/dev-workflow")"
+
+assert_eq "normalize_mount_source: /mnt/<drive>/...（WSL）も同じ表現に正規化する" \
+  "C:/users/mimay/documents/github/dev-workflow" \
+  "$(normalize_mount_source "/mnt/c/Users/mimay/Documents/github/dev-workflow")"
+
+assert_eq "normalize_mount_source: //<drive>/...（Git Bash 等）も同じ表現に正規化する" \
+  "C:/users/mimay/documents/github/dev-workflow" \
+  "$(normalize_mount_source "//c/Users/mimay/Documents/github/dev-workflow")"
+
+assert_eq "normalize_mount_source: バックスラッシュ区切りもスラッシュへ統一する" \
+  "C:/users/mimay/repo" \
+  "$(normalize_mount_source 'C:\Users\mimay\repo')"
+
+assert_eq "normalize_mount_source: ドライブ形式でない通常の Unix パスは大小文字を変えずそのまま返す" \
+  "/home/User/Repo" \
+  "$(normalize_mount_source "/home/User/Repo")"
+
+# ---------------------------------------------------------------------------
+# ケース7b: container_belongs_to_repo（Docker 非依存の所属判定関数、Task #6 / issue #29）
+#
+# label あり／label なしの旧命名残骸／他リポジトリの各パターンに加え、
+# dev-workflow.root label による同名 basename・別 root の判別（issue #29）と、
+# Docker Desktop 形式マウント元の正規化済み比較（issue #25）を、docker を一切
 # 起動せずに純粋関数として直接検証する。
+#
+# シグネチャ: container_belongs_to_repo <label_repo> <label_root> <mount_source> <host_root> <project>
 # ---------------------------------------------------------------------------
 
 echo "== container_belongs_to_repo（所属判定・Docker 非依存） =="
@@ -379,46 +448,87 @@ echo "== container_belongs_to_repo（所属判定・Docker 非依存） =="
 
 HOST_ROOT_SAMPLE="/home/user/repo"
 
-if container_belongs_to_repo "myrepo" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
-  pass "label の repo が一致すれば対象に含まれる"
+if container_belongs_to_repo "myrepo" "$HOST_ROOT_SAMPLE" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  pass "label の repo と root label が一致すれば対象に含まれる"
 else
-  fail "label の repo が一致すれば対象に含まれる"
+  fail "label の repo と root label が一致すれば対象に含まれる"
 fi
 
-if container_belongs_to_repo "otherrepo" "${HOST_ROOT_SAMPLE}/anything" "$HOST_ROOT_SAMPLE" "myrepo"; then
+if container_belongs_to_repo "myrepo" "/home/user2/repo" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  fail "同名 basename でも root label が不一致なら対象に含まれない（issue #29）" "含まれてしまいました"
+else
+  pass "同名 basename でも root label が不一致なら対象に含まれない（issue #29）"
+fi
+
+if container_belongs_to_repo "otherrepo" "" "${HOST_ROOT_SAMPLE}/anything" "$HOST_ROOT_SAMPLE" "myrepo"; then
   fail "label の repo が不一致なら対象に含まれない" "含まれてしまいました（マウント元が一致していても label 不一致を優先すべき）"
 else
   pass "label の repo が不一致なら対象に含まれない"
 fi
 
-if container_belongs_to_repo "" "${HOST_ROOT_SAMPLE}/.claude/worktrees/agent-old" "$HOST_ROOT_SAMPLE" "myrepo"; then
+if container_belongs_to_repo "myrepo" "" "${HOST_ROOT_SAMPLE}/anything" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  pass "root label が空（旧コンテナ）の場合はマウント元判定にフォールバックする"
+else
+  fail "root label が空（旧コンテナ）の場合はマウント元判定にフォールバックする"
+fi
+
+if container_belongs_to_repo "myrepo" "" "/home/user/other-repo/subdir" "$HOST_ROOT_SAMPLE" "myrepo"; then
+  fail "root label が空でもマウント元が別リポジトリなら対象に含まれない" "含まれてしまいました"
+else
+  pass "root label が空でもマウント元が別リポジトリなら対象に含まれない"
+fi
+
+if container_belongs_to_repo "" "" "${HOST_ROOT_SAMPLE}/.claude/worktrees/agent-old" "$HOST_ROOT_SAMPLE" "myrepo"; then
   pass "label なし・マウント元がリポジトリルート配下なら対象に含まれる（旧命名の残骸回収）"
 else
   fail "label なし・マウント元がリポジトリルート配下なら対象に含まれる"
 fi
 
-if container_belongs_to_repo "" "$HOST_ROOT_SAMPLE" "$HOST_ROOT_SAMPLE" "myrepo"; then
+if container_belongs_to_repo "" "" "$HOST_ROOT_SAMPLE" "$HOST_ROOT_SAMPLE" "myrepo"; then
   pass "label なし・マウント元がリポジトリルート自身でも対象に含まれる"
 else
   fail "label なし・マウント元がリポジトリルート自身でも対象に含まれる"
 fi
 
-if container_belongs_to_repo "" "/home/user/other-repo/subdir" "$HOST_ROOT_SAMPLE" "myrepo"; then
+if container_belongs_to_repo "" "" "/home/user/other-repo/subdir" "$HOST_ROOT_SAMPLE" "myrepo"; then
   fail "label なし・マウント元が別リポジトリなら対象に含まれない" "含まれてしまいました"
 else
   pass "label なし・マウント元が別リポジトリなら対象に含まれない"
 fi
 
-if container_belongs_to_repo "" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
+if container_belongs_to_repo "" "" "" "$HOST_ROOT_SAMPLE" "myrepo"; then
   fail "label もマウント元も無ければ対象に含まれない" "含まれてしまいました"
 else
   pass "label もマウント元も無ければ対象に含まれない"
 fi
 
+# --- issue #25: label なし・Docker Desktop 形式のマウント元でも正規化して同一ツリーと判定する ---
+if container_belongs_to_repo "" "" "/run/desktop/mnt/host/c/Users/mimay/Documents/github/dev-workflow" \
+    "C:/Users/mimay/Documents/github/dev-workflow" "dev-workflow"; then
+  pass "label なし・Docker Desktop 形式のマウント元でも正規化して同一ツリーと判定する（issue #25）"
+else
+  fail "label なし・Docker Desktop 形式のマウント元でも正規化して同一ツリーと判定する（issue #25）"
+fi
+
+if container_belongs_to_repo "" "" "/run/desktop/mnt/host/c/Users/mimay/Documents/github/other-repo" \
+    "C:/Users/mimay/Documents/github/dev-workflow" "dev-workflow"; then
+  fail "Docker Desktop 形式でも別ツリーなら対象に含まれない" "含まれてしまいました"
+else
+  pass "Docker Desktop 形式でも別ツリーなら対象に含まれない"
+fi
+
+# --- issue #29: root label が Docker Desktop 形式・pwd -W 形式など異なる表現でも正規化して一致する ---
+if container_belongs_to_repo "myrepo" "/run/desktop/mnt/host/c/Users/mimay/repo" "" \
+    "C:/Users/mimay/repo" "myrepo"; then
+  pass "root label が別表現（Docker Desktop 形式）でも正規化して一致すれば対象に含まれる（issue #29）"
+else
+  fail "root label が別表現（Docker Desktop 形式）でも正規化して一致すれば対象に含まれる（issue #29）"
+fi
+
 # ---------------------------------------------------------------------------
 # ケース8: --ls / --down --all（偽 docker で label・マウント元を注入し、実際の docker を起動せず検証する）
 #
-# 偽 docker は DW_TEST_MANIFEST（name|managed|repo|epic|image|status|created|mount_source
+# 偽 docker は DW_TEST_MANIFEST（name|managed|repo|epic|image|status|created|mount_source|root_label
 # の '|' 区切り行）を読み、docker ps / docker container inspect / docker rm を模擬する。
 # `docker rm` は本物を一切呼ばず、DW_TEST_RM_LOG に対象名を追記するだけにする。
 # ---------------------------------------------------------------------------
@@ -439,15 +549,18 @@ DW_TEST_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/dw-test-manifest.XXXXXX")"
 DW_TEST_RM_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-rmlog.XXXXXX")"
 : > "$DW_TEST_RM_LOG"
 
-# 1) label ありで現リポジトリに属するコンテナ（現行の起動中コンテナを模す）
+# 1) label ありで現リポジトリに属するコンテナ（現行の起動中コンテナを模す。root label も一致）
 # 2) label なしの旧命名残骸で、マウント元が現リポジトリのルート配下（回収されるべき）
 # 3) label ありで他リポジトリに属するコンテナ（--down --all の対象に含まれてはいけない）
 # 4) label なしで、マウント元が他リポジトリ配下（対象に含まれてはいけない）
+# 5) label ありで repo（basename）は一致するが root label が異なる（別クローン。issue #29。
+#    --down --all の対象に含まれてはいけない）
 cat > "$DW_TEST_MANIFEST" <<MANIFEST
-dw-sandbox-${LS_REPO_BASENAME}|1|${LS_REPO_BASENAME}||dev-sandbox:${LS_REPO_BASENAME}|running|2024-01-01T00:00:00Z|${LS_HOST_ROOT}
-dw-sandbox-${LS_REPO_BASENAME}-legacy|||||exited|2023-01-01T00:00:00Z|${LS_HOST_ROOT}/.claude/worktrees/agent-old
-dw-sandbox-otherrepo|1|otherrepo||dev-sandbox:otherrepo|running|2024-02-02T00:00:00Z|/home/user/otherrepo
-dw-sandbox-otherrepo-legacy|||||exited|2023-03-03T00:00:00Z|/home/user/otherrepo/subdir
+dw-sandbox-${LS_REPO_BASENAME}|1|${LS_REPO_BASENAME}||dev-sandbox:${LS_REPO_BASENAME}|running|2024-01-01T00:00:00Z|${LS_HOST_ROOT}|${LS_HOST_ROOT}
+dw-sandbox-${LS_REPO_BASENAME}-legacy|||||exited|2023-01-01T00:00:00Z|${LS_HOST_ROOT}/.claude/worktrees/agent-old|
+dw-sandbox-otherrepo|1|otherrepo||dev-sandbox:otherrepo|running|2024-02-02T00:00:00Z|/home/user/otherrepo|/home/user/otherrepo
+dw-sandbox-otherrepo-legacy|||||exited|2023-03-03T00:00:00Z|/home/user/otherrepo/subdir|
+dw-sandbox-${LS_REPO_BASENAME}-otherclone|1|${LS_REPO_BASENAME}||dev-sandbox:${LS_REPO_BASENAME}|running|2024-03-03T00:00:00Z|/home/otheruser/${LS_REPO_BASENAME}|/home/otheruser/${LS_REPO_BASENAME}
 MANIFEST
 
 FAKE_DOCKER_MANIFEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin-manifest.XXXXXX")"
@@ -496,8 +609,9 @@ case "${1:-}" in
     done
     line="$(manifest_line "$name")"
     [ -n "$line" ] || exit 1
-    IFS='|' read -r f_name f_managed f_repo f_epic f_image f_status f_created f_mount <<< "$line"
+    IFS='|' read -r f_name f_managed f_repo f_epic f_image f_status f_created f_mount f_root <<< "$line"
     case "$tmpl" in
+      *'dev-workflow.root'*) printf '%s\n' "$f_root" ;;
       *'dev-workflow.repo'*) printf '%s\n' "$f_repo" ;;
       *'dev-workflow.epic'*) printf '%s\n' "$f_epic" ;;
       *'Mounts'*)            printf '%s\n' "$f_mount" ;;
@@ -588,6 +702,12 @@ else
   pass "--down --all は他リポジトリのコンテナを列挙しない"
 fi
 
+if printf '%s\n' "$DOWN_ALL_OUTPUT" | grep -q "otherclone"; then
+  fail "--down --all は repo(basename) が同じでも root label が異なるコンテナを列挙しない（issue #29）" "output=[${DOWN_ALL_OUTPUT}]"
+else
+  pass "--down --all は repo(basename) が同じでも root label が異なるコンテナを列挙しない（issue #29）"
+fi
+
 RM_LOG_CONTENT="$(cat "$DW_TEST_RM_LOG")"
 RM_LOG_COUNT="$(printf '%s\n' "$RM_LOG_CONTENT" | grep -c . || true)"
 assert_eq "--down --all は自リポジトリ分の2件だけを docker rm する" "2" "$RM_LOG_COUNT"
@@ -597,6 +717,34 @@ if printf '%s\n' "$RM_LOG_CONTENT" | grep -q "otherrepo"; then
 else
   pass "--down --all は他リポジトリのコンテナを削除しない"
 fi
+
+if printf '%s\n' "$RM_LOG_CONTENT" | grep -q "otherclone"; then
+  fail "--down --all は repo(basename) が同じでも root label が異なるコンテナを削除しない（issue #29）" "rm_log=[${RM_LOG_CONTENT}]"
+else
+  pass "--down --all は repo(basename) が同じでも root label が異なるコンテナを削除しない（issue #29）"
+fi
+
+# --- --down（単体）: 削除対象名を表示し、現在の repo+epic のコンテナ1個だけを rm する（issue #30） ---
+: > "$DW_TEST_RM_LOG"
+DOWN_SINGLE_OUTPUT="$(
+  cd "$LS_REPO" || exit 1
+  DW_TEST_MANIFEST="$DW_TEST_MANIFEST" DW_TEST_RM_LOG="$DW_TEST_RM_LOG" \
+    PATH="${FAKE_DOCKER_MANIFEST_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --down
+)"
+
+case "$DOWN_SINGLE_OUTPUT" in
+  *"削除対象のコンテナ: dw-sandbox-${LS_REPO_BASENAME}"*)
+    pass "--down（単体）は削除対象名を表示する（issue #30）" ;;
+  *)
+    fail "--down（単体）は削除対象名を表示する（issue #30）" "output=[${DOWN_SINGLE_OUTPUT}]" ;;
+esac
+
+DOWN_SINGLE_RM_CONTENT="$(cat "$DW_TEST_RM_LOG")"
+DOWN_SINGLE_RM_COUNT="$(printf '%s\n' "$DOWN_SINGLE_RM_CONTENT" | grep -c . || true)"
+assert_eq "--down（単体）は当該コンテナ1件だけを docker rm する（issue #30）" "1" "$DOWN_SINGLE_RM_COUNT"
+assert_eq "--down（単体）は現在の repo+epic のコンテナ名を rm する（issue #30）" \
+  "dw-sandbox-${LS_REPO_BASENAME}" "$DOWN_SINGLE_RM_CONTENT"
 
 # ---------------------------------------------------------------------------
 # ケース9: --reset-cache のガード（列挙・running 検出・--force。Task #7、Epic #3 仕様書 4.6）
@@ -770,6 +918,9 @@ IMG_DOCKERFILE="$(plan_value dockerfile "$IMG_PLAN_AFTER_CHANGE")"
 IMG_BUILD_CONTEXT="$(plan_value build_context "$IMG_PLAN_AFTER_CHANGE")"
 IMG_CONTAINER="$(plan_value container "$IMG_PLAN_AFTER_CHANGE")"
 IMG_MOUNT_SOURCE="$(plan_value mount_source "$IMG_PLAN_AFTER_CHANGE")"
+IMG_WORKDIR="$(plan_value workdir "$IMG_PLAN_AFTER_CHANGE")"
+IMG_REPO_NAME="$(plan_value repo "$IMG_PLAN_AFTER_CHANGE")"
+IMG_HOST_ROOT="$(plan_value repo_root "$IMG_PLAN_AFTER_CHANGE")"
 
 # --- 内容が同じなら別リポジトリ（worktree 相当）でも hash が変わらない ---
 IMG_REPO2="$(make_temp_repo)"
@@ -875,14 +1026,16 @@ case "${1:-}" in
   exec)
     shift
     cmd=""
+    workdir=""
     while [ $# -gt 0 ]; do
       case "$1" in
-        -w) shift 2 ;;
+        -w) workdir="$2"; shift 2 ;;
         sh) shift ;;
         -c) cmd="$2"; shift 2 ;;
         *)  shift ;;
       esac
     done
+    printf '%s\n' "$workdir" >> "${DW_IMG_EXEC_LOG:?DW_IMG_EXEC_LOG is required}"
     sh -c "$cmd"
     exit $?
     ;;
@@ -896,6 +1049,7 @@ chmod +x "${FAKE_DOCKER_IMAGE_DIR}/docker"
 IMG_TEST_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imglog.XXXXXX")"
 IMG_TEST_RM_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgrmlog.XXXXXX")"
 IMG_TEST_RUN_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgrunlog.XXXXXX")"
+IMG_TEST_EXEC_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgexeclog.XXXXXX")"
 IMG_TEST_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgstate.XXXXXX")"
 IMG_TEST_RUNNING_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgrunning.XXXXXX")"
 
@@ -909,6 +1063,7 @@ run_img_case() {
   : > "$IMG_TEST_LOG"
   : > "$IMG_TEST_RM_LOG"
   : > "$IMG_TEST_RUN_LOG"
+  : > "$IMG_TEST_EXEC_LOG"
   printf '%s' "$container_exists" > "$IMG_TEST_STATE_FILE"
   printf '%s\n' "$container_running" > "$IMG_TEST_RUNNING_FILE"
 
@@ -917,6 +1072,7 @@ run_img_case() {
     DW_IMG_LOG="$IMG_TEST_LOG" \
       DW_IMG_RM_LOG="$IMG_TEST_RM_LOG" \
       DW_IMG_RUN_LOG="$IMG_TEST_RUN_LOG" \
+      DW_IMG_EXEC_LOG="$IMG_TEST_EXEC_LOG" \
       DW_IMG_CONTAINER_STATE="$IMG_TEST_STATE_FILE" \
       DW_IMG_CONTAINER_RUNNING_STATE="$IMG_TEST_RUNNING_FILE" \
       DW_IMG_CONTAINER_IMAGE_ID="$container_image_id" \
@@ -936,6 +1092,50 @@ assert_exit_code "イメージ未存在時: 実行全体が成功する" 0 "$IMG
 IMG_A_BUILD_LINE="$(grep '^build ' "$IMG_TEST_LOG" | head -n1)"
 assert_eq "イメージ未存在時: docker build が正しい引数で呼ばれる" \
   "build -f ${IMG_DOCKERFILE} -t ${IMG_IMAGE} ${IMG_BUILD_CONTEXT}" "$IMG_A_BUILD_LINE"
+
+# --- コンテナが無い場合の docker run に label / マウント / workdir が正しく渡る（issue #30） ---
+# これまで DW_IMG_RUN_LOG は記録するだけで一度もアサートしていなかった
+# （label ベースの後片付け全体がこの配線に依存しているにもかかわらず）。
+IMG_A_RUN_LINE="$(head -n1 "$IMG_TEST_RUN_LOG")"
+
+case "$IMG_A_RUN_LINE" in
+  *"--label dev-workflow.managed=1"*)
+    pass "イメージ未存在時: docker run に --label dev-workflow.managed=1 が渡る（issue #30）" ;;
+  *)
+    fail "イメージ未存在時: docker run に --label dev-workflow.managed=1 が渡る（issue #30）" "run_line=[${IMG_A_RUN_LINE}]" ;;
+esac
+
+case "$IMG_A_RUN_LINE" in
+  *"--label dev-workflow.repo=${IMG_REPO_NAME}"*)
+    pass "イメージ未存在時: docker run に --label dev-workflow.repo=<repo> が渡る（issue #30）" ;;
+  *)
+    fail "イメージ未存在時: docker run に --label dev-workflow.repo=<repo> が渡る（issue #30）" "run_line=[${IMG_A_RUN_LINE}]" ;;
+esac
+
+case "$IMG_A_RUN_LINE" in
+  *"--label dev-workflow.epic="*)
+    pass "イメージ未存在時: docker run に --label dev-workflow.epic=<epic> が渡る（issue #30）" ;;
+  *)
+    fail "イメージ未存在時: docker run に --label dev-workflow.epic=<epic> が渡る（issue #30）" "run_line=[${IMG_A_RUN_LINE}]" ;;
+esac
+
+case "$IMG_A_RUN_LINE" in
+  *"--label dev-workflow.root=${IMG_HOST_ROOT}"*)
+    pass "イメージ未存在時: docker run に --label dev-workflow.root=<host_root> が渡る（issue #30）" ;;
+  *)
+    fail "イメージ未存在時: docker run に --label dev-workflow.root=<host_root> が渡る（issue #30）" "run_line=[${IMG_A_RUN_LINE}]" ;;
+esac
+
+case "$IMG_A_RUN_LINE" in
+  *"-v ${IMG_MOUNT_SOURCE}:/workspace"*)
+    pass "イメージ未存在時: docker run に -v <mount_source>:/workspace が渡る（issue #30）" ;;
+  *)
+    fail "イメージ未存在時: docker run に -v <mount_source>:/workspace が渡る（issue #30）" "run_line=[${IMG_A_RUN_LINE}]" ;;
+esac
+
+IMG_A_EXEC_WORKDIR="$(head -n1 "$IMG_TEST_EXEC_LOG")"
+assert_eq "イメージ未存在時: docker exec に解決済み workdir が -w で渡る（issue #30）" \
+  "$IMG_WORKDIR" "$IMG_A_EXEC_WORKDIR"
 
 # --- イメージが存在する場合はビルドしない ---
 IMG_B_EXIT=0
@@ -1011,6 +1211,70 @@ assert_eq "イメージID同一時: 既存コンテナを削除しない" "0" "$
 
 IMG_F_RUN_COUNT="$(grep -c '^run ' "$IMG_TEST_LOG" || true)"
 assert_eq "イメージID同一時: コンテナを作り直さない" "0" "$IMG_F_RUN_COUNT"
+
+# ---------------------------------------------------------------------------
+# マウント元不一致による再作成の検証（issue #30）
+#
+# これまでの既存コンテナありケース（E・F）はどちらも container_mount に
+# $IMG_MOUNT_SOURCE をそのまま渡しており、マウント元が期待値と異なる場合に
+# 再作成される分岐（仕様書 4.3 の2。この Epic の「静かに間違ったツリーを
+# 実行しない」ための本体）を検証するケースが存在しなかった。
+#
+# docker_desktop_equivalent は、実際の IMG_MOUNT_SOURCE の形式（Windows の
+# pwd -W 形式か、Linux 等の素のパスか）に応じて「同一ツリーを指す別表現」を
+# 作る。ドライブレター形式なら Docker Desktop の変換済みパス
+# （/run/desktop/mnt/host/<drive>/...）へ、そうでなければバックスラッシュ区切りへ
+# 変換する。どちらの実行環境でも normalize_mount_source が同一表現へ正規化する
+# ことを、実際の sandbox-exec.sh（docker はモック）経由で確認するため。
+# ---------------------------------------------------------------------------
+
+docker_desktop_equivalent() {
+  # docker_desktop_equivalent <mount_source>
+  local src="$1" drive rest
+  case "$src" in
+    [A-Za-z]:/*|[A-Za-z]:)
+      drive="${src%%:*}"
+      rest="${src#*:}"
+      drive="$(printf '%s' "$drive" | tr '[:upper:]' '[:lower:]')"
+      printf '/run/desktop/mnt/host/%s%s' "$drive" "$rest"
+      ;;
+    *)
+      printf '%s' "${src//\//\\}"
+      ;;
+  esac
+}
+
+IMG_MOUNT_EQUIVALENT="$(docker_desktop_equivalent "$IMG_MOUNT_SOURCE")"
+IMG_G_STDERR_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgg-stderr.XXXXXX")"
+
+# --- (a) container_mount が MOUNT_SOURCE と異なる場合は削除して作り直す ---
+IMG_G_EXIT=0
+run_img_case 1 true "sha256:same" "${IMG_MOUNT_SOURCE}/different-tree" 1 "sha256:same" 'true' \
+  2>"$IMG_G_STDERR_FILE" >/dev/null || IMG_G_EXIT=$?
+assert_exit_code "マウント元不一致時: 実行全体が成功する（issue #30）" 0 "$IMG_G_EXIT"
+
+IMG_G_RM_COUNT="$(grep -c . "$IMG_TEST_RM_LOG" || true)"
+assert_eq "マウント元不一致時: 既存コンテナが削除される（issue #30）" "1" "$IMG_G_RM_COUNT"
+
+IMG_G_RUN_COUNT="$(grep -c '^run ' "$IMG_TEST_LOG" || true)"
+assert_eq "マウント元不一致時: コンテナが作り直される（issue #30）" "1" "$IMG_G_RUN_COUNT"
+
+IMG_G_STDERR="$(cat "$IMG_G_STDERR_FILE")"
+case "$IMG_G_STDERR" in
+  *"別ツリー実行の防止"*) pass "マウント元不一致時: 別ツリー実行の防止の警告が出る（issue #30）" ;;
+  *) fail "マウント元不一致時: 別ツリー実行の防止の警告が出る（issue #30）" "stderr=[${IMG_G_STDERR}]" ;;
+esac
+
+# --- (b) Docker Desktop 形式（等）でも同一ツリーと判定され再作成されない ---
+IMG_H_EXIT=0
+run_img_case 1 true "sha256:same" "$IMG_MOUNT_EQUIVALENT" 1 "sha256:same" 'true' >/dev/null 2>&1 || IMG_H_EXIT=$?
+assert_exit_code "マウント元が別表現でも同一ツリー時: 実行全体が成功する（issue #30）" 0 "$IMG_H_EXIT"
+
+IMG_H_RM_COUNT="$(grep -c . "$IMG_TEST_RM_LOG" || true)"
+assert_eq "マウント元が別表現（Docker Desktop 形式等）でも同一ツリーなら削除しない（issue #25 / #30）" "0" "$IMG_H_RM_COUNT"
+
+IMG_H_RUN_COUNT="$(grep -c '^run ' "$IMG_TEST_LOG" || true)"
+assert_eq "マウント元が別表現（Docker Desktop 形式等）でも同一ツリーなら作り直さない（issue #25 / #30）" "0" "$IMG_H_RUN_COUNT"
 
 # ---------------------------------------------------------------------------
 # ケース10: compose_conflict_warnings（Docker 非依存の衝突検出関数、Task #9）

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# dev-workflow: このリポジトリ自身を検証するテストランナー（ベンダー中立・Docker 非依存）
+#
+# bats 等の外部依存を追加せず、素の bash アサーションだけで組み立てる。
+# ここに書くテストは Docker を一切呼び出さない。`scripts/sandbox-exec.sh --print-plan`
+# のようなドライラン出力・構文チェックのみを対象にする（Docker を使う検証は別途サンドボックス内で行う）。
+#
+# 使い方:
+#   bash tests/run-tests.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+FAILED_CASES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  ok   - $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILED_CASES+=("$1")
+  echo "  NG   - $1"
+  [ -n "${2:-}" ] && echo "         ${2}"
+}
+
+skip() {
+  SKIP=$((SKIP + 1))
+  echo "  skip - $1 (${2:-})"
+}
+
+assert_eq() {
+  # assert_eq <説明> <期待値> <実際の値>
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "expected=[${expected}] actual=[${actual}]"
+  fi
+}
+
+assert_exit_code() {
+  # assert_exit_code <説明> <期待する終了コード> <実際の終了コード>
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" -eq "$actual" ]; then
+    pass "$desc"
+  else
+    fail "$desc" "expected exit=${expected} actual exit=${actual}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 一時 git リポジトリ / worktree を組み立てるヘルパ。
+# 後続タスク（epic worktree / agent worktree / リポジトリ外 worktree のケース追加）で再利用する。
+# 一時ディレクトリは mktemp -d 配下に限定し、削除コマンドは実行しない
+# （OS のテンポラリ領域に任せる。破壊的コマンドを避けるため明示的な rm は行わない）。
+# ---------------------------------------------------------------------------
+
+make_temp_repo() {
+  # 新規の一時 git リポジトリを作り、初回コミットまで済ませてパスを返す。
+  local dir
+  dir="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-repo.XXXXXX")"
+  (
+    cd "$dir" || exit 1
+    git init -q
+    git config user.email "dev-workflow-test@example.com"
+    git config user.name "dev-workflow test"
+    printf 'test repo\n' > README.md
+    git add README.md
+    git commit -q -m "init"
+  ) >/dev/null 2>&1
+  printf '%s' "$dir"
+}
+
+make_worktree() {
+  # make_worktree <repo_dir> <worktree_dir> <branch>
+  # repo_dir に対して worktree_dir へ新しいブランチの worktree を追加する。
+  local repo_dir="$1" worktree_dir="$2" branch="$3"
+  (
+    cd "$repo_dir" || exit 1
+    git worktree add -q -b "$branch" "$worktree_dir"
+  ) >/dev/null 2>&1
+}
+
+copy_sandbox_scripts() {
+  # copy_sandbox_scripts <dest_repo_dir>
+  # sandbox-exec.sh / resolve-sandbox.sh / Dockerfile.dev を検証対象の一時リポジトリへ複製する。
+  local dest="$1"
+  mkdir -p "${dest}/scripts"
+  cp "${REPO_ROOT}/scripts/sandbox-exec.sh"   "${dest}/scripts/sandbox-exec.sh"
+  cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
+  cp "${REPO_ROOT}/Dockerfile.dev"             "${dest}/Dockerfile.dev"
+}
+
+# ---------------------------------------------------------------------------
+# ケース1: 全 scripts/*.sh に対する bash -n（構文チェック）
+# ---------------------------------------------------------------------------
+
+echo "== bash -n（構文チェック） =="
+
+for script in "${REPO_ROOT}"/scripts/*.sh; do
+  name="$(basename "$script")"
+  bashn_out="$(bash -n "$script" 2>&1)"
+  if [ $? -eq 0 ]; then
+    pass "bash -n: ${name}"
+  else
+    fail "bash -n: ${name}" "$bashn_out"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# ケース2: shellcheck（あれば実行。無ければ skip 扱いで通す）
+# ---------------------------------------------------------------------------
+
+echo "== shellcheck（利用可能な場合のみ） =="
+
+if command -v shellcheck >/dev/null 2>&1; then
+  for script in "${REPO_ROOT}"/scripts/*.sh; do
+    name="$(basename "$script")"
+    shellcheck_out="$(shellcheck "$script" 2>&1)"
+    if [ $? -eq 0 ]; then
+      pass "shellcheck: ${name}"
+    else
+      fail "shellcheck: ${name}" "$shellcheck_out"
+    fi
+  done
+else
+  skip "shellcheck" "コマンドが見つからないためスキップ"
+fi
+
+# ---------------------------------------------------------------------------
+# ケース3: --print-plan がドライランであること（docker を一切呼ばない）
+# ---------------------------------------------------------------------------
+
+echo "== --print-plan（ドライラン） =="
+
+PRINT_PLAN_REPO="$(make_temp_repo)"
+copy_sandbox_scripts "$PRINT_PLAN_REPO"
+
+# 実際に docker を呼んでいないことを検出するため、docker という名前の偽コマンドを
+# PATH の先頭に置き、呼ばれたらマーカーファイルを残して失敗させる。
+FAKE_BIN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin.XXXXXX")"
+DOCKER_CALLED_MARKER="${FAKE_BIN_DIR}/docker-called-marker"
+cat > "${FAKE_BIN_DIR}/docker" <<'FAKE_DOCKER'
+#!/bin/bash
+echo "$@" >> "${DOCKER_CALLED_MARKER}"
+exit 1
+FAKE_DOCKER
+chmod +x "${FAKE_BIN_DIR}/docker"
+
+PRINT_PLAN_OUTPUT="$(
+  cd "$PRINT_PLAN_REPO" || exit 1
+  DOCKER_CALLED_MARKER="$DOCKER_CALLED_MARKER" PATH="${FAKE_BIN_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --print-plan
+)"
+PRINT_PLAN_EXIT=$?
+
+assert_exit_code "--print-plan は exit 0 で終わる" 0 "$PRINT_PLAN_EXIT"
+
+if [ -f "$DOCKER_CALLED_MARKER" ]; then
+  fail "--print-plan は docker を起動しない" "docker が呼ばれました: $(cat "$DOCKER_CALLED_MARKER")"
+else
+  pass "--print-plan は docker を起動しない"
+fi
+
+get_plan_value() {
+  # get_plan_value <key>  出力から key=value の value 部分（先頭一致1件）を取り出す
+  printf '%s\n' "$PRINT_PLAN_OUTPUT" | grep "^${1}=" | head -n1 | cut -d'=' -f2-
+}
+
+REPO_BASENAME="$(basename "$PRINT_PLAN_REPO")"
+
+assert_eq "mode=dockerfile" "dockerfile" "$(get_plan_value mode)"
+assert_eq "repo は一時リポジトリのディレクトリ名と一致" "$REPO_BASENAME" "$(get_plan_value repo)"
+assert_eq "epic 未指定時は空" "" "$(get_plan_value epic)"
+assert_eq "mount_target は /workspace" "/workspace" "$(get_plan_value mount_target)"
+assert_eq "workdir は /workspace" "/workspace" "$(get_plan_value workdir)"
+assert_eq "container はリポジトリ名から決まる" "dw-sandbox-${REPO_BASENAME}" "$(get_plan_value container)"
+assert_eq "image はリポジトリ名から決まる" "dev-sandbox:${REPO_BASENAME}" "$(get_plan_value image)"
+
+# mount_source はこのケースでは一時リポジトリのパス（pwd -W 相当）を指すはず。
+MOUNT_SOURCE="$(get_plan_value mount_source)"
+case "$MOUNT_SOURCE" in
+  *"$REPO_BASENAME") pass "mount_source が一時リポジトリを指す" ;;
+  *) fail "mount_source が一時リポジトリを指す" "mount_source=[${MOUNT_SOURCE}]" ;;
+esac
+
+# cache_volume が複数行、key=value:path 形式で出ていることを確認する。
+CACHE_VOLUME_COUNT="$(printf '%s\n' "$PRINT_PLAN_OUTPUT" | grep -c '^cache_volume=')"
+if [ "$CACHE_VOLUME_COUNT" -gt 0 ]; then
+  pass "cache_volume が1件以上出力される（${CACHE_VOLUME_COUNT}件）"
+else
+  fail "cache_volume が1件以上出力される" "0件でした"
+fi
+
+FIRST_CACHE_LINE="$(printf '%s\n' "$PRINT_PLAN_OUTPUT" | grep '^cache_volume=' | head -n1)"
+case "$FIRST_CACHE_LINE" in
+  cache_volume=dw-cache-"${REPO_BASENAME}"-*:*) pass "cache_volume の命名がリポジトリ単位である" ;;
+  *) fail "cache_volume の命名がリポジトリ単位である" "実際の1行目: ${FIRST_CACHE_LINE}" ;;
+esac
+
+# --epic 指定時にコンテナ名へ反映されることも、この段階の挙動として確認しておく。
+PRINT_PLAN_EPIC_OUTPUT="$(
+  cd "$PRINT_PLAN_REPO" || exit 1
+  DOCKER_CALLED_MARKER="$DOCKER_CALLED_MARKER" PATH="${FAKE_BIN_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --epic epic999 --print-plan
+)"
+EPIC_CONTAINER="$(printf '%s\n' "$PRINT_PLAN_EPIC_OUTPUT" | grep '^container=' | cut -d'=' -f2-)"
+assert_eq "--epic 指定時はコンテナ名に反映される" "dw-sandbox-${REPO_BASENAME}-epic999" "$EPIC_CONTAINER"
+
+if [ -f "$DOCKER_CALLED_MARKER" ]; then
+  fail "--epic 付き --print-plan も docker を起動しない" "docker が呼ばれました: $(cat "$DOCKER_CALLED_MARKER")"
+else
+  pass "--epic 付き --print-plan も docker を起動しない"
+fi
+
+# ---------------------------------------------------------------------------
+# 結果集計
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "== 結果: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped =="
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "失敗したケース:"
+  for c in "${FAILED_CASES[@]}"; do
+    echo "  - ${c}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1397,12 +1397,59 @@ COMPOSE_CASE_EPIC_OUTPUT="$(print_plan_in "$COMPOSE_EPIC_WORKTREE_DIR")"
 assert_eq "compose: epic worktree の compose_project も agent worktree と同一" \
   "$(plan_value compose_project "$COMPOSE_CASE_AGENT_OUTPUT")" "$(plan_value compose_project "$COMPOSE_CASE_EPIC_OUTPUT")"
 
+# --- リポジトリ外の worktree（フォールバック）では compose_project も分離される（issue #27） ---
+#
+# 修正前は CONTAINER だけがフォールバック接尾辞で分離され、COMPOSE_PROJECT は
+# 常に dw-<repo> のままだった。compose は project 名だけで既存サービスを探すため、
+# リポジトリルートからの実行とリポジトリ外worktreeからの実行が同じ project を
+# 共有してしまい、片方が起動した compose サービスへもう片方が警告なしに exec してしまう
+# （実行系の再現テストは下記の compose_project 分離を前提にした別ケースで検証する）。
+COMPOSE_OUTSIDE_WORKTREE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-compose-outside.XXXXXX")"
+make_worktree "$COMPOSE_REPO" "$COMPOSE_OUTSIDE_WORKTREE_DIR" "compose-outside-worktree-branch"
+
+COMPOSE_CASE_OUTSIDE_STDERR="$(mktemp "${TMPDIR:-/tmp}/dw-test-compose-outside-stderr.XXXXXX")"
+COMPOSE_CASE_OUTSIDE_OUTPUT="$(
+  cd "$COMPOSE_OUTSIDE_WORKTREE_DIR" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan 2>"$COMPOSE_CASE_OUTSIDE_STDERR"
+)"
+
+assert_eq "compose: リポジトリ外worktreeでは fallback=1" "1" "$(plan_value fallback "$COMPOSE_CASE_OUTSIDE_OUTPUT")"
+
+COMPOSE_OUTSIDE_PROJECT="$(plan_value compose_project "$COMPOSE_CASE_OUTSIDE_OUTPUT")"
+COMPOSE_ROOT_PROJECT="$(plan_value compose_project "$COMPOSE_CASE1_OUTPUT")"
+if [ "$COMPOSE_OUTSIDE_PROJECT" != "$COMPOSE_ROOT_PROJECT" ]; then
+  pass "compose: リポジトリ外worktree（フォールバック）では compose_project が分離される（issue #27）"
+else
+  fail "compose: リポジトリ外worktree（フォールバック）では compose_project が分離される（issue #27）" \
+    "compose_project=[${COMPOSE_OUTSIDE_PROJECT}]（共有 project と同一でした）"
+fi
+
+COMPOSE_OUTSIDE_CONTAINER="$(plan_value container "$COMPOSE_CASE_OUTSIDE_OUTPUT")"
+COMPOSE_ROOT_CONTAINER="$(plan_value container "$COMPOSE_CASE1_OUTPUT")"
+if [ "$COMPOSE_OUTSIDE_CONTAINER" != "$COMPOSE_ROOT_CONTAINER" ]; then
+  pass "compose: リポジトリ外worktree（フォールバック）では container も分離される（issue #27）"
+else
+  fail "compose: リポジトリ外worktree（フォールバック）では container も分離される（issue #27）" \
+    "container=[${COMPOSE_OUTSIDE_CONTAINER}]（共有コンテナと同一でした）"
+fi
+
+if [ -s "$COMPOSE_CASE_OUTSIDE_STDERR" ]; then
+  pass "compose: リポジトリ外worktreeのフォールバック時に stderr へ警告する"
+else
+  fail "compose: リポジトリ外worktreeのフォールバック時に stderr へ警告する" "stderr が空でした"
+fi
+
 # ---------------------------------------------------------------------------
 # compose モードの実行系（偽 docker で `docker compose` を模擬する）。
 #
 # 偽 docker は `compose -p PROJECT --project-directory DIR -f FILE <サブコマンド>...`
 # を解釈し、状態ファイルでサービスの running / not-running を切り替える。
 # 実際の docker には一切触れない。呼び出し引数は DW_COMPOSE_LOG にすべて記録する。
+#
+# DW_COMPOSE_MOUNT_SOURCE（既定は未設定=空）: `container inspect -f <Mountsを含むテンプレート>`
+# の戻り値。既存サービスのマウント元検証（issue #27）を検証するために使う。
+# `docker rm -f <id>` を呼ぶと状態ファイルを空にし、以後 running ではなくなったものとして扱う
+# （issue #27 の「不一致なら削除して作り直す」を再現するため）。
 # ---------------------------------------------------------------------------
 
 FAKE_DOCKER_COMPOSE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin-compose.XXXXXX")"
@@ -1415,6 +1462,7 @@ LOG="${DW_COMPOSE_LOG:?DW_COMPOSE_LOG is required}"
 STATE_FILE="${DW_COMPOSE_SERVICE_STATE:?DW_COMPOSE_SERVICE_STATE is required}"   # "" | running
 UP_SUCCEEDS="${DW_COMPOSE_UP_SUCCEEDS:-1}"
 WORKDIR_OK="${DW_COMPOSE_WORKDIR_OK:-1}"
+MOUNT_SOURCE="${DW_COMPOSE_MOUNT_SOURCE:-}"
 
 echo "$*" >> "$LOG"
 
@@ -1444,6 +1492,10 @@ case "${1:-}" in
         fi
         exit 0
         ;;
+      down)
+        printf '\n' > "$STATE_FILE"
+        exit 0
+        ;;
       exec)
         case "$*" in
           *"test -d"*)
@@ -1471,14 +1523,29 @@ case "${1:-}" in
     shift
     [ "${1:-}" = "inspect" ] || exit 1
     shift
+    tmpl=""
     while [ $# -gt 0 ]; do
       case "$1" in
-        -f) shift 2 ;;
+        -f) tmpl="$2"; shift 2 ;;
         *)  shift ;;
       esac
     done
-    state="$(cat "$STATE_FILE" 2>/dev/null || true)"
-    if [ "$state" = "running" ]; then echo "true"; else echo "false"; fi
+    case "$tmpl" in
+      *'Mounts'*)
+        printf '%s\n' "$MOUNT_SOURCE"
+        ;;
+      *)
+        state="$(cat "$STATE_FILE" 2>/dev/null || true)"
+        if [ "$state" = "running" ]; then echo "true"; else echo "false"; fi
+        ;;
+    esac
+    exit 0
+    ;;
+  rm)
+    shift
+    # `docker rm -f <id>`。マウント元不一致で再作成する際に呼ばれる（issue #27）。
+    # 実際の docker には触れず、状態ファイルを空にして「削除済み」を再現する。
+    printf '\n' > "$STATE_FILE"
     exit 0
     ;;
   *)
@@ -1493,6 +1560,8 @@ COMPOSE_TEST_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-composestate.XXXXXX")
 
 run_compose_case() {
   # run_compose_case <dir> <initial_state> <up_succeeds 0/1> <workdir_ok 0/1> [追加のsandbox-exec.sh引数...]
+  # 環境変数 COMPOSE_TEST_MOUNT_SOURCE が設定されていれば、既存サービスのマウント元検証
+  # （issue #27）を再現するための DW_COMPOSE_MOUNT_SOURCE として渡す（未設定なら空のまま）。
   local dir="$1" initial_state="$2" up_succeeds="$3" workdir_ok="$4"
   shift 4
 
@@ -1505,6 +1574,7 @@ run_compose_case() {
       DW_COMPOSE_SERVICE_STATE="$COMPOSE_TEST_STATE_FILE" \
       DW_COMPOSE_UP_SUCCEEDS="$up_succeeds" \
       DW_COMPOSE_WORKDIR_OK="$workdir_ok" \
+      DW_COMPOSE_MOUNT_SOURCE="${COMPOSE_TEST_MOUNT_SOURCE:-}" \
       PATH="${FAKE_DOCKER_COMPOSE_DIR}:${PATH}" \
       bash scripts/sandbox-exec.sh "$@"
   )
@@ -1610,6 +1680,84 @@ COMPOSE_WARN_STDERR="$(
 case "$COMPOSE_WARN_STDERR" in
   *"container_name"*) pass "compose: 実行時に container_name の衝突警告が stderr に出る" ;;
   *) fail "compose: 実行時に container_name の衝突警告が stderr に出る" "stderr=[${COMPOSE_WARN_STDERR}]" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 既存サービスが running でも、マウント元が期待値（MOUNT_SOURCE）と異なれば削除して
+# 作り直す（issue #27）。フォールバック時の compose_project 分離（本コミットで修正済み）が
+# 主たる対策だが、その二重チェックとして dockerfile モードと同様の検証をここでも固定する。
+# ---------------------------------------------------------------------------
+
+echo "== compose: 既存サービスのマウント元検証（issue #27） =="
+
+COMPOSE_TEST_MOUNT_SOURCE="/some/other/tree"
+COMPOSE_MISMATCH_STDERR="$(run_compose_case "$COMPOSE_REPO" "running" 1 1 'true' 2>&1 1>/dev/null)"
+COMPOSE_MISMATCH_EXIT=$?
+unset COMPOSE_TEST_MOUNT_SOURCE
+
+assert_exit_code "compose: マウント元不一致を検出して削除・作り直し後に成功する（issue #27）" 0 "$COMPOSE_MISMATCH_EXIT"
+
+case "$COMPOSE_MISMATCH_STDERR" in
+  *"マウント元"*"削除して作り直します"*)
+    pass "compose: 既存サービスのマウント元不一致を検出して警告する（issue #27）" ;;
+  *)
+    fail "compose: 既存サービスのマウント元不一致を検出して警告する（issue #27）" \
+      "stderr=[${COMPOSE_MISMATCH_STDERR}]" ;;
+esac
+
+if grep -q '^rm -f fake-compose-container-id$' "$COMPOSE_TEST_LOG"; then
+  pass "compose: マウント元不一致の既存コンテナを docker rm -f で削除する（issue #27）"
+else
+  fail "compose: マウント元不一致の既存コンテナを docker rm -f で削除する（issue #27）" \
+    "log=[$(cat "$COMPOSE_TEST_LOG")]"
+fi
+
+if grep -q ' up -d app$' "$COMPOSE_TEST_LOG"; then
+  pass "compose: マウント元不一致で削除した後は up -d で作り直す（issue #27）"
+else
+  fail "compose: マウント元不一致で削除した後は up -d で作り直す（issue #27）" \
+    "log=[$(cat "$COMPOSE_TEST_LOG")]"
+fi
+
+# --- マウント元が一致していれば、running なサービスを削除せず再利用する（回帰防止） ---
+COMPOSE_TEST_MOUNT_SOURCE="$COMPOSE_HOST_ROOT"
+COMPOSE_MATCH_EXIT=0
+run_compose_case "$COMPOSE_REPO" "running" 1 1 'true' >/dev/null 2>&1 || COMPOSE_MATCH_EXIT=$?
+unset COMPOSE_TEST_MOUNT_SOURCE
+
+assert_exit_code "compose: マウント元一致時は成功する" 0 "$COMPOSE_MATCH_EXIT"
+
+if grep -q '^rm -f fake-compose-container-id$' "$COMPOSE_TEST_LOG"; then
+  fail "compose: マウント元が一致していれば既存コンテナを削除しない（回帰防止）" \
+    "log=[$(cat "$COMPOSE_TEST_LOG")]"
+else
+  pass "compose: マウント元が一致していれば既存コンテナを削除しない（回帰防止）"
+fi
+
+# ---------------------------------------------------------------------------
+# --down が compose モードのとき docker compose down を -p / --project-directory 付きで
+# 呼ぶことを固定する（issue #28）。本 Epic で compose モードは対象サービスが running で
+# なければ up -d を自動実行するようになった一方、以前の --down は dw-sandbox-* という
+# 名前のコンテナしか削除せず、compose が起動したコンテナを落とす主体がいなかった。
+# ---------------------------------------------------------------------------
+
+echo "== compose: --down（issue #28） =="
+
+COMPOSE_DOWN_EXIT=0
+COMPOSE_DOWN_STDOUT="$(run_compose_case "$COMPOSE_REPO" "running" 1 1 --down 2>/dev/null)" || COMPOSE_DOWN_EXIT=$?
+assert_exit_code "compose: --down は成功する（issue #28）" 0 "$COMPOSE_DOWN_EXIT"
+
+case "$(cat "$COMPOSE_TEST_LOG")" in
+  *"compose -p dw-${COMPOSE_REPO_BASENAME} --project-directory ${COMPOSE_HOST_ROOT} -f docker-compose.dev.yml down"*)
+    pass "compose: --down は docker compose down を -p / --project-directory 付きで呼ぶ（issue #28）" ;;
+  *)
+    fail "compose: --down は docker compose down を -p / --project-directory 付きで呼ぶ（issue #28）" \
+      "log=[$(cat "$COMPOSE_TEST_LOG")]" ;;
+esac
+
+case "$COMPOSE_DOWN_STDOUT" in
+  *"dw-${COMPOSE_REPO_BASENAME}"*) pass "compose: --down の出力に project 名が表示される（issue #28）" ;;
+  *) fail "compose: --down の出力に project 名が表示される（issue #28）" "output=[${COMPOSE_DOWN_STDOUT}]" ;;
 esac
 
 # ---------------------------------------------------------------------------

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -193,7 +193,31 @@ assert_eq "epic 未指定時は空" "" "$(get_plan_value epic)"
 assert_eq "mount_target は /workspace" "/workspace" "$(get_plan_value mount_target)"
 assert_eq "workdir は /workspace" "/workspace" "$(get_plan_value workdir)"
 assert_eq "container はリポジトリ名から決まる" "dw-sandbox-${REPO_BASENAME}" "$(get_plan_value container)"
-assert_eq "image はリポジトリ名から決まる" "dev-sandbox:${REPO_BASENAME}" "$(get_plan_value image)"
+
+# image はリポジトリ名 + Dockerfile.dev 内容の hash8（Task #8、仕様書 4.7）で決まる。
+# hash8 の具体的な値は Dockerfile.dev の内容依存のため、ここではプレフィックスと
+# 末尾8文字が16進数であることだけを確認する（内容変更への追随はケース7で検証する）。
+IMAGE_VALUE="$(get_plan_value image)"
+case "$IMAGE_VALUE" in
+  "dev-sandbox:${REPO_BASENAME}-"*) pass "image はリポジトリ名+hash8のプレフィックスを持つ" ;;
+  *) fail "image はリポジトリ名+hash8のプレフィックスを持つ" "image=[${IMAGE_VALUE}]" ;;
+esac
+
+IMAGE_HASH_SUFFIX="${IMAGE_VALUE: -8}"
+case "$IMAGE_HASH_SUFFIX" in
+  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])
+    pass "image の末尾8文字が16進数のhashである" ;;
+  *)
+    fail "image の末尾8文字が16進数のhashである" "suffix=[${IMAGE_HASH_SUFFIX}]" ;;
+esac
+
+assert_eq "dockerfile は Dockerfile.dev" "Dockerfile.dev" "$(get_plan_value dockerfile)"
+
+BUILD_CONTEXT_VALUE="$(get_plan_value build_context)"
+case "$BUILD_CONTEXT_VALUE" in
+  *"$REPO_BASENAME") pass "--print-plan に build_context が出る（一時リポジトリを指す）" ;;
+  *) fail "--print-plan に build_context が出る（一時リポジトリを指す）" "build_context=[${BUILD_CONTEXT_VALUE}]" ;;
+esac
 
 # mount_source はこのケースでは一時リポジトリのパス（pwd -W 相当）を指すはず。
 MOUNT_SOURCE="$(get_plan_value mount_source)"
@@ -675,6 +699,300 @@ case "$RESET_BLOCK_STDERR" in
   *"リポジトリ全体"*) pass "中断メッセージにも作用範囲（リポジトリ全体）の記載がある" ;;
   *) fail "中断メッセージにも作用範囲（リポジトリ全体）の記載がある" "stderr=[${RESET_BLOCK_STDERR}]" ;;
 esac
+
+# ---------------------------------------------------------------------------
+# ケース7: イメージタグの hash 依存性（Task #8、Epic #3 仕様書「5. 検証方針」ケース7）
+#
+# Dockerfile.dev の内容を変更するとタグの hash 部分（末尾8文字）が変わり、内容が同じなら
+# 別リポジトリでも hash が変わらないことを確認する。
+# ---------------------------------------------------------------------------
+
+echo "== イメージタグの hash 依存性（ケース7、Task #8） =="
+
+IMG_REPO="$(make_temp_repo)"
+copy_sandbox_scripts "$IMG_REPO"
+
+IMG_PLAN_OUTPUT="$(
+  cd "$IMG_REPO" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan
+)"
+IMG_IMAGE="$(plan_value image "$IMG_PLAN_OUTPUT")"
+IMG_DOCKERFILE="$(plan_value dockerfile "$IMG_PLAN_OUTPUT")"
+IMG_BUILD_CONTEXT="$(plan_value build_context "$IMG_PLAN_OUTPUT")"
+IMG_CONTAINER="$(plan_value container "$IMG_PLAN_OUTPUT")"
+IMG_MOUNT_SOURCE="$(plan_value mount_source "$IMG_PLAN_OUTPUT")"
+IMG_HASH_BEFORE="${IMG_IMAGE: -8}"
+
+# --- Dockerfile.dev の内容を変更してコミットすると hash（タグの末尾8文字）が変わる ---
+printf '\n# case7 marker\n' >> "${IMG_REPO}/Dockerfile.dev"
+(
+  cd "$IMG_REPO" || exit 1
+  git add Dockerfile.dev
+  git commit -q -m "case7: change Dockerfile.dev"
+) >/dev/null 2>&1
+
+IMG_PLAN_AFTER_CHANGE="$(
+  cd "$IMG_REPO" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan
+)"
+IMG_IMAGE_AFTER_CHANGE="$(plan_value image "$IMG_PLAN_AFTER_CHANGE")"
+IMG_HASH_AFTER_CHANGE="${IMG_IMAGE_AFTER_CHANGE: -8}"
+
+if [ "$IMG_HASH_BEFORE" != "$IMG_HASH_AFTER_CHANGE" ]; then
+  pass "ケース7: Dockerfile.dev の内容変更でタグの hash が変わる"
+else
+  fail "ケース7: Dockerfile.dev の内容変更でタグの hash が変わる" "hash が変わりませんでした: ${IMG_HASH_BEFORE}"
+fi
+
+# 以降の自動ビルド系テストは、この時点（Dockerfile.dev 変更後）の IMG_REPO を使い回す。
+# resolve-sandbox.sh の出力は Dockerfile.dev の内容に追随するため、変更後の値で
+# 上書きしておかないと docker build の実引数と食い違う。
+IMG_IMAGE="$(plan_value image "$IMG_PLAN_AFTER_CHANGE")"
+IMG_DOCKERFILE="$(plan_value dockerfile "$IMG_PLAN_AFTER_CHANGE")"
+IMG_BUILD_CONTEXT="$(plan_value build_context "$IMG_PLAN_AFTER_CHANGE")"
+IMG_CONTAINER="$(plan_value container "$IMG_PLAN_AFTER_CHANGE")"
+IMG_MOUNT_SOURCE="$(plan_value mount_source "$IMG_PLAN_AFTER_CHANGE")"
+
+# --- 内容が同じなら別リポジトリ（worktree 相当）でも hash が変わらない ---
+IMG_REPO2="$(make_temp_repo)"
+copy_sandbox_scripts "$IMG_REPO2"
+
+IMG_PLAN2_OUTPUT="$(
+  cd "$IMG_REPO2" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan
+)"
+IMG_HASH2="$(plan_value image "$IMG_PLAN2_OUTPUT")"
+IMG_HASH2="${IMG_HASH2: -8}"
+
+assert_eq "ケース7: 内容が同じなら別リポジトリでも hash が変わらない" "$IMG_HASH_BEFORE" "$IMG_HASH2"
+
+# ---------------------------------------------------------------------------
+# 自動ビルド・--rebuild・イメージID差分による再作成（Task #8、Epic #3 仕様書 4.7 / 4.3 の1）
+#
+# 偽 docker は状態をファイルに保持し、docker build / docker rm / docker run の呼び出しを
+# 実際の docker を起動せずに検証する。container の存在状態は docker rm / docker run に
+# 応じて更新するため、削除後に作り直されることまで検証できる。
+# ---------------------------------------------------------------------------
+
+echo "== 自動ビルド・--rebuild・イメージID差分による再作成（Task #8） =="
+
+FAKE_DOCKER_IMAGE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-fakebin-image.XXXXXX")"
+cat > "${FAKE_DOCKER_IMAGE_DIR}/docker" <<'FAKE_DOCKER_IMAGE'
+#!/bin/bash
+# tests/run-tests.sh 用の偽 docker（イメージ解決・自動ビルド・コンテナ再作成の検証専用）。
+# 実際の docker には一切触れない。呼び出し引数は DW_IMG_LOG にすべて記録する。
+set -u
+
+IMG_LOG="${DW_IMG_LOG:?DW_IMG_LOG is required}"
+STATE_FILE="${DW_IMG_CONTAINER_STATE:?DW_IMG_CONTAINER_STATE is required}"          # 1=存在 0=不在
+RUNNING_FILE="${DW_IMG_CONTAINER_RUNNING_STATE:?DW_IMG_CONTAINER_RUNNING_STATE is required}" # true/false
+RM_LOG="${DW_IMG_RM_LOG:?DW_IMG_RM_LOG is required}"
+RUN_LOG="${DW_IMG_RUN_LOG:?DW_IMG_RUN_LOG is required}"
+
+echo "$*" >> "$IMG_LOG"
+
+case "${1:-}" in
+  image)
+    shift
+    [ "${1:-}" = "inspect" ] || exit 1
+    shift
+    tmpl=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -f) tmpl="$2"; shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    [ "${DW_IMG_IMAGE_EXISTS:-0}" = "1" ] || exit 1
+    [ -n "$tmpl" ] && printf '%s\n' "${DW_IMG_IMAGE_ID:-sha256:default-image-id}"
+    exit 0
+    ;;
+  build)
+    exit "${DW_IMG_BUILD_EXIT:-0}"
+    ;;
+  container)
+    shift
+    [ "${1:-}" = "inspect" ] || exit 1
+    shift
+    tmpl=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -f) tmpl="$2"; shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    [ "$(cat "$STATE_FILE" 2>/dev/null)" = "1" ] || exit 1
+    case "$tmpl" in
+      *'Mounts'*)        printf '%s\n' "${DW_IMG_CONTAINER_MOUNT:-}" ;;
+      *'.Image'*)        printf '%s\n' "${DW_IMG_CONTAINER_IMAGE_ID:-}" ;;
+      *'State.Running'*) cat "$RUNNING_FILE" 2>/dev/null || printf 'false\n' ;;
+      '') : ;;
+      *) printf '\n' ;;
+    esac
+    exit 0
+    ;;
+  run)
+    echo "$*" >> "$RUN_LOG"
+    printf '1' > "$STATE_FILE"
+    printf 'true\n' > "$RUNNING_FILE"
+    exit 0
+    ;;
+  start)
+    printf 'true\n' > "$RUNNING_FILE"
+    exit 0
+    ;;
+  rm)
+    shift
+    target=""
+    for a in "$@"; do
+      case "$a" in
+        -f) ;;
+        *)  target="$a" ;;
+      esac
+    done
+    echo "$target" >> "$RM_LOG"
+    printf '0' > "$STATE_FILE"
+    exit 0
+    ;;
+  exec)
+    shift
+    cmd=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -w) shift 2 ;;
+        sh) shift ;;
+        -c) cmd="$2"; shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    sh -c "$cmd"
+    exit $?
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+FAKE_DOCKER_IMAGE
+chmod +x "${FAKE_DOCKER_IMAGE_DIR}/docker"
+
+IMG_TEST_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imglog.XXXXXX")"
+IMG_TEST_RM_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgrmlog.XXXXXX")"
+IMG_TEST_RUN_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgrunlog.XXXXXX")"
+IMG_TEST_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgstate.XXXXXX")"
+IMG_TEST_RUNNING_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-imgrunning.XXXXXX")"
+
+run_img_case() {
+  # run_img_case <container_exists 0/1> <container_running true/false> <container_image_id>
+  #              <container_mount> <image_exists 0/1> <image_id> [追加の sandbox-exec.sh 引数...]
+  local container_exists="$1" container_running="$2" container_image_id="$3" container_mount="$4"
+  local image_exists="$5" image_id="$6"
+  shift 6
+
+  : > "$IMG_TEST_LOG"
+  : > "$IMG_TEST_RM_LOG"
+  : > "$IMG_TEST_RUN_LOG"
+  printf '%s' "$container_exists" > "$IMG_TEST_STATE_FILE"
+  printf '%s\n' "$container_running" > "$IMG_TEST_RUNNING_FILE"
+
+  (
+    cd "$IMG_REPO" || exit 1
+    DW_IMG_LOG="$IMG_TEST_LOG" \
+      DW_IMG_RM_LOG="$IMG_TEST_RM_LOG" \
+      DW_IMG_RUN_LOG="$IMG_TEST_RUN_LOG" \
+      DW_IMG_CONTAINER_STATE="$IMG_TEST_STATE_FILE" \
+      DW_IMG_CONTAINER_RUNNING_STATE="$IMG_TEST_RUNNING_FILE" \
+      DW_IMG_CONTAINER_IMAGE_ID="$container_image_id" \
+      DW_IMG_CONTAINER_MOUNT="$container_mount" \
+      DW_IMG_IMAGE_EXISTS="$image_exists" \
+      DW_IMG_IMAGE_ID="$image_id" \
+      PATH="${FAKE_DOCKER_IMAGE_DIR}:${PATH}" \
+      bash scripts/sandbox-exec.sh "$@"
+  )
+}
+
+# --- イメージが存在しない場合、docker build が正しい引数で呼ばれる ---
+IMG_A_EXIT=0
+run_img_case 0 false "" "" 0 "" 'true' >/dev/null 2>&1 || IMG_A_EXIT=$?
+assert_exit_code "イメージ未存在時: 実行全体が成功する" 0 "$IMG_A_EXIT"
+
+IMG_A_BUILD_LINE="$(grep '^build ' "$IMG_TEST_LOG" | head -n1)"
+assert_eq "イメージ未存在時: docker build が正しい引数で呼ばれる" \
+  "build -f ${IMG_DOCKERFILE} -t ${IMG_IMAGE} ${IMG_BUILD_CONTEXT}" "$IMG_A_BUILD_LINE"
+
+# --- イメージが存在する場合はビルドしない ---
+IMG_B_EXIT=0
+run_img_case 0 false "" "" 1 "sha256:existing" 'true' >/dev/null 2>&1 || IMG_B_EXIT=$?
+assert_exit_code "イメージ存在時: 実行全体が成功する" 0 "$IMG_B_EXIT"
+
+IMG_B_BUILD_COUNT="$(grep -c '^build ' "$IMG_TEST_LOG" || true)"
+assert_eq "イメージ存在時: docker build を呼ばない" "0" "$IMG_B_BUILD_COUNT"
+
+# --- --rebuild 指定時は存在してもビルドする ---
+IMG_C_EXIT=0
+run_img_case 0 false "" "" 1 "sha256:existing" --rebuild 'true' >/dev/null 2>&1 || IMG_C_EXIT=$?
+assert_exit_code "--rebuild 指定時: 実行全体が成功する" 0 "$IMG_C_EXIT"
+
+IMG_C_BUILD_COUNT="$(grep -c '^build ' "$IMG_TEST_LOG" || true)"
+assert_eq "--rebuild 指定時: イメージが存在してもビルドする" "1" "$IMG_C_BUILD_COUNT"
+
+# --- DEV_WORKFLOW_DOCKER_IMAGE 指定でイメージが無い場合はビルドせずエラーで停止する ---
+: > "$IMG_TEST_LOG"
+: > "$IMG_TEST_RM_LOG"
+: > "$IMG_TEST_RUN_LOG"
+printf '0' > "$IMG_TEST_STATE_FILE"
+printf 'false\n' > "$IMG_TEST_RUNNING_FILE"
+
+EXPLICIT_IMAGE_STDERR="$(
+  cd "$IMG_REPO" || exit 1
+  DEV_WORKFLOW_DOCKER_IMAGE="external/image:notfound" \
+    DW_IMG_LOG="$IMG_TEST_LOG" \
+    DW_IMG_RM_LOG="$IMG_TEST_RM_LOG" \
+    DW_IMG_RUN_LOG="$IMG_TEST_RUN_LOG" \
+    DW_IMG_CONTAINER_STATE="$IMG_TEST_STATE_FILE" \
+    DW_IMG_CONTAINER_RUNNING_STATE="$IMG_TEST_RUNNING_FILE" \
+    DW_IMG_IMAGE_EXISTS=0 \
+    PATH="${FAKE_DOCKER_IMAGE_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh 'true' 2>&1 1>/dev/null
+)"
+EXPLICIT_IMAGE_EXIT=$?
+
+if [ "$EXPLICIT_IMAGE_EXIT" -ne 0 ]; then
+  pass "DEV_WORKFLOW_DOCKER_IMAGE 指定でイメージが無い場合は非0で終了する"
+else
+  fail "DEV_WORKFLOW_DOCKER_IMAGE 指定でイメージが無い場合は非0で終了する" "exit=0"
+fi
+
+EXPLICIT_IMAGE_BUILD_COUNT="$(grep -c '^build ' "$IMG_TEST_LOG" || true)"
+assert_eq "DEV_WORKFLOW_DOCKER_IMAGE 指定時: イメージが無くてもビルドしない" "0" "$EXPLICIT_IMAGE_BUILD_COUNT"
+
+case "$EXPLICIT_IMAGE_STDERR" in
+  *"DEV_WORKFLOW_DOCKER_IMAGE"*"external/image:notfound"*)
+    pass "DEV_WORKFLOW_DOCKER_IMAGE 指定時のエラーに取得方法の案内が含まれる" ;;
+  *)
+    fail "DEV_WORKFLOW_DOCKER_IMAGE 指定時のエラーに取得方法の案内が含まれる" "stderr=[${EXPLICIT_IMAGE_STDERR}]" ;;
+esac
+
+# --- 既存コンテナのイメージIDが異なれば削除して作り直す（仕様書 4.3 の1） ---
+IMG_E_EXIT=0
+run_img_case 1 true "sha256:old" "$IMG_MOUNT_SOURCE" 1 "sha256:new" 'true' >/dev/null 2>&1 || IMG_E_EXIT=$?
+assert_exit_code "イメージID差分時: 実行全体が成功する" 0 "$IMG_E_EXIT"
+
+IMG_E_RM_COUNT="$(grep -c . "$IMG_TEST_RM_LOG" || true)"
+assert_eq "イメージID差分時: 既存コンテナが削除される" "1" "$IMG_E_RM_COUNT"
+
+IMG_E_RUN_COUNT="$(grep -c '^run ' "$IMG_TEST_LOG" || true)"
+assert_eq "イメージID差分時: コンテナが作り直される" "1" "$IMG_E_RUN_COUNT"
+
+# --- 既存コンテナのイメージIDが同じなら作り直さない ---
+IMG_F_EXIT=0
+run_img_case 1 true "sha256:same" "$IMG_MOUNT_SOURCE" 1 "sha256:same" 'true' >/dev/null 2>&1 || IMG_F_EXIT=$?
+assert_exit_code "イメージID同一時: 実行全体が成功する" 0 "$IMG_F_EXIT"
+
+IMG_F_RM_COUNT="$(grep -c . "$IMG_TEST_RM_LOG" || true)"
+assert_eq "イメージID同一時: 既存コンテナを削除しない" "0" "$IMG_F_RM_COUNT"
+
+IMG_F_RUN_COUNT="$(grep -c '^run ' "$IMG_TEST_LOG" || true)"
+assert_eq "イメージID同一時: コンテナを作り直さない" "0" "$IMG_F_RUN_COUNT"
 
 # ---------------------------------------------------------------------------
 # 結果集計

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1463,10 +1463,59 @@ STATE_FILE="${DW_COMPOSE_SERVICE_STATE:?DW_COMPOSE_SERVICE_STATE is required}"  
 UP_SUCCEEDS="${DW_COMPOSE_UP_SUCCEEDS:-1}"
 WORKDIR_OK="${DW_COMPOSE_WORKDIR_OK:-1}"
 MOUNT_SOURCE="${DW_COMPOSE_MOUNT_SOURCE:-}"
+# issue #34 用: 「project|working_dir|running」形式のマニフェスト（1行1project）。
+# list_compose_projects_in_repo() の top-level `docker ps -a --filter
+# label=com.docker.compose.project ...` を模擬するために使う（未設定なら空扱い）。
+PROJECTS_MANIFEST="${DW_COMPOSE_PROJECTS_MANIFEST:-}"
+# issue #32 用: 1にすると一覧取得（label=com.docker.compose.project 単体フィルタ）を
+# 実機で観測したテンプレート誤用と同様に失敗させ、非0終了 + stderr 出力を模擬する。
+PS_FAIL="${DW_COMPOSE_PS_FAIL:-0}"
 
 echo "$*" >> "$LOG"
 
 case "${1:-}" in
+  ps)
+    shift
+    filter=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -a) shift ;;
+        --filter) filter="$2"; shift 2 ;;
+        --format) shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    case "$filter" in
+      "label=com.docker.compose.project")
+        if [ "$PS_FAIL" = "1" ]; then
+          echo 'failed to execute template: error calling index: cannot index slice/array with type string' >&2
+          exit 1
+        fi
+        # 自リポジトリ・他リポジトリ両方の compose project をマニフェストのまま返す。
+        # どれを対象にするかは production 側（正規化して working_dir を判定）に委ねる。
+        if [ -n "$PROJECTS_MANIFEST" ] && [ -f "$PROJECTS_MANIFEST" ]; then
+          while IFS='|' read -r m_proj m_wd _m_running; do
+            [ -n "$m_proj" ] || continue
+            printf '%s|%s\n' "$m_proj" "$m_wd"
+          done < "$PROJECTS_MANIFEST"
+        fi
+        exit 0
+        ;;
+      label=com.docker.compose.project=*)
+        target_proj="${filter#label=com.docker.compose.project=}"
+        if [ -n "$PROJECTS_MANIFEST" ] && [ -f "$PROJECTS_MANIFEST" ]; then
+          while IFS='|' read -r m_proj _m_wd m_running; do
+            [ "$m_proj" = "$target_proj" ] || continue
+            [ "$m_running" = "running" ] && echo "fake-compose-container-id"
+          done < "$PROJECTS_MANIFEST"
+        fi
+        exit 0
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
   compose)
     shift
     # 先頭の共通オプション（-p / --project-directory / -f）を読み飛ばしてサブコマンドを取り出す
@@ -2250,6 +2299,180 @@ RG31_TIMEOUT_EXIT=0
 )
 RG31_TIMEOUT_EXIT=$?
 assert_exit_code "複数行読み取りに変えた後も、入力が来ない場合はタイムアウトしてexit 0で素通りする" 0 "$RG31_TIMEOUT_EXIT"
+
+# ---------------------------------------------------------------------------
+# compose: --down --all / --ls の project 絞り込み（レビュー2巡目 issue #32 / #33 / #34）
+#
+# list_compose_projects_in_repo() は本Epicのレビューで次の2点を指摘された:
+#   - issue #32: docker ps のフォーマットで `{{ index .Labels "..." }}` を使っていたが、
+#     `docker ps` コンテキストでは .Labels は map ではなく文字列であり必ず失敗する。
+#     正しくは `{{.Label "..."}}`。失敗を 2>/dev/null で握り潰さず、非0終了時は
+#     stderr に警告を出すことも合わせて固定する。
+#   - issue #33: 絞り込みが project 名の接頭辞一致だけで、他リポジトリ（basename が
+#     接頭辞になる／同じ basename を別ディレクトリにクローンした）の project を
+#     巻き込みうる。正しくは com.docker.compose.project.working_dir label
+#     （--project-directory に渡した値）を正規化して HOST_ROOT 配下のものだけを対象にする。
+#
+# 上記2つの穴は、偽 docker が compose モードの `ps`（-a なし・ありの両方）を
+# 未実装（*) exit 1）だったため一度もテストされていなかった（issue #34）。
+# FAKE_DOCKER_COMPOSE に「project|working_dir|running」形式のマニフェストで駆動する
+# ps 実装を追加した（DW_COMPOSE_PROJECTS_MANIFEST）ので、ここでそれを使って固定する。
+# 実 docker には一切触れない。
+# ---------------------------------------------------------------------------
+
+echo "== compose: --down --all / --ls の project 絞り込み（issue #32 / #33 / #34） =="
+
+COMPOSE_PROJECTS_LOG="$(mktemp "${TMPDIR:-/tmp}/dw-test-composeprojlog.XXXXXX")"
+COMPOSE_PROJECTS_STATE="$(mktemp "${TMPDIR:-/tmp}/dw-test-composeprojstate.XXXXXX")"
+: > "$COMPOSE_PROJECTS_STATE"
+
+COMPOSE_PROJECTS_MANIFEST_FILE="$(mktemp "${TMPDIR:-/tmp}/dw-test-composeprojects.XXXXXX")"
+
+# 他リポジトリのマウント元は正規化後も HOST_ROOT と一致しない、実在しないダミーパスでよい。
+COMPOSE_OTHER_CLONE_ROOT="/some/other/clone/root"
+COMPOSE_UNRELATED_ROOT="/home/user/otherrepo"
+
+# 1) 自リポジトリ・epicなし（--project-directory は常に HOST_ROOT）
+# 2) 自リポジトリ・epicあり（working_dir は同じ HOST_ROOT）
+# 3) 他リポジトリ。project 名は自リポジトリの basename が接頭辞になっている
+#    （旧・接頭辞一致ロジックなら誤って巻き込んでいた。working_dir は無関係な別root）
+# 4) 自リポジトリと「同名」の project だが working_dir が別root
+#    （同じ basename を別ディレクトリにクローンした場合を模す。issue #33 (b) / (c)）
+# 5) 全く無関係な他リポジトリ
+cat > "$COMPOSE_PROJECTS_MANIFEST_FILE" <<MANIFEST
+dw-${COMPOSE_REPO_BASENAME}|${COMPOSE_HOST_ROOT}|running
+dw-${COMPOSE_REPO_BASENAME}-epicx|${COMPOSE_HOST_ROOT}|stopped
+dw-${COMPOSE_REPO_BASENAME}-otherclone|${COMPOSE_OTHER_CLONE_ROOT}|running
+dw-${COMPOSE_REPO_BASENAME}|${COMPOSE_OTHER_CLONE_ROOT}|running
+dw-otherrepo|${COMPOSE_UNRELATED_ROOT}|running
+MANIFEST
+
+run_compose_projects_case() {
+  # run_compose_projects_case <sandbox-exec.shへの引数...>
+  (
+    cd "$COMPOSE_REPO" || exit 1
+    DW_COMPOSE_LOG="$COMPOSE_PROJECTS_LOG" \
+      DW_COMPOSE_SERVICE_STATE="$COMPOSE_PROJECTS_STATE" \
+      DW_COMPOSE_PROJECTS_MANIFEST="$COMPOSE_PROJECTS_MANIFEST_FILE" \
+      PATH="${FAKE_DOCKER_COMPOSE_DIR}:${PATH}" \
+      bash scripts/sandbox-exec.sh "$@"
+  )
+}
+
+# --- --ls は自リポジトリの compose project の状態のみ表示する（issue #34 の3点目） ---
+: > "$COMPOSE_PROJECTS_LOG"
+COMPOSE_LS_OUTPUT="$(run_compose_projects_case --ls)"
+
+case "$COMPOSE_LS_OUTPUT" in
+  *"dw-${COMPOSE_REPO_BASENAME}"*"running"*)
+    pass "compose: --ls は自リポジトリの compose project を running で表示する" ;;
+  *)
+    fail "compose: --ls は自リポジトリの compose project を running で表示する" \
+      "output=[${COMPOSE_LS_OUTPUT}]" ;;
+esac
+
+case "$COMPOSE_LS_OUTPUT" in
+  *"dw-${COMPOSE_REPO_BASENAME}-epicx"*"stopped"*)
+    pass "compose: --ls は自リポジトリの別epic project を stopped で表示する" ;;
+  *)
+    fail "compose: --ls は自リポジトリの別epic project を stopped で表示する" \
+      "output=[${COMPOSE_LS_OUTPUT}]" ;;
+esac
+
+if printf '%s\n' "$COMPOSE_LS_OUTPUT" | grep -q "otherclone"; then
+  fail "compose: --ls は basename が接頭辞一致するだけの他リポジトリ project を表示しない（issue #33）" \
+    "output=[${COMPOSE_LS_OUTPUT}]"
+else
+  pass "compose: --ls は basename が接頭辞一致するだけの他リポジトリ project を表示しない（issue #33）"
+fi
+
+if printf '%s\n' "$COMPOSE_LS_OUTPUT" | grep -q "otherrepo"; then
+  fail "compose: --ls は無関係な他リポジトリ project を表示しない" "output=[${COMPOSE_LS_OUTPUT}]"
+else
+  pass "compose: --ls は無関係な他リポジトリ project を表示しない"
+fi
+
+# --- --down --all は自リポジトリの project すべてを down し、他リポジトリは down しない（issue #34 の1・2点目） ---
+: > "$COMPOSE_PROJECTS_LOG"
+COMPOSE_DOWN_ALL_EXIT=0
+run_compose_projects_case --down --all >/dev/null 2>&1 || COMPOSE_DOWN_ALL_EXIT=$?
+assert_exit_code "compose: --down --all は成功する" 0 "$COMPOSE_DOWN_ALL_EXIT"
+
+DOWN_ALL_LOG_CONTENT="$(cat "$COMPOSE_PROJECTS_LOG")"
+
+DOWN_COUNT_SELF_NOEPIC="$(printf '%s\n' "$DOWN_ALL_LOG_CONTENT" \
+  | grep -Fc "compose -p dw-${COMPOSE_REPO_BASENAME} --project-directory ${COMPOSE_HOST_ROOT} -f docker-compose.dev.yml down" || true)"
+assert_eq "compose: --down --all は自リポジトリの project（epicなし）を down する（issue #34）" "1" "$DOWN_COUNT_SELF_NOEPIC"
+
+DOWN_COUNT_SELF_EPIC="$(printf '%s\n' "$DOWN_ALL_LOG_CONTENT" \
+  | grep -Fc "compose -p dw-${COMPOSE_REPO_BASENAME}-epicx --project-directory ${COMPOSE_HOST_ROOT} -f docker-compose.dev.yml down" || true)"
+assert_eq "compose: --down --all は自リポジトリの別epic project も down する（issue #34）" "1" "$DOWN_COUNT_SELF_EPIC"
+
+if printf '%s\n' "$DOWN_ALL_LOG_CONTENT" | grep -q "otherclone"; then
+  fail "compose: --down --all は basename が接頭辞一致するだけの他リポジトリ project を down しない（issue #33）" \
+    "log=[${DOWN_ALL_LOG_CONTENT}]"
+else
+  pass "compose: --down --all は basename が接頭辞一致するだけの他リポジトリ project を down しない（issue #33）"
+fi
+
+if printf '%s\n' "$DOWN_ALL_LOG_CONTENT" | grep -q "otherrepo"; then
+  fail "compose: --down --all は無関係な他リポジトリ project を down しない" "log=[${DOWN_ALL_LOG_CONTENT}]"
+else
+  pass "compose: --down --all は無関係な他リポジトリ project を down しない"
+fi
+
+# 同名別root（issue #33 (b)/(c)）: 自プロジェクトと同一名だが working_dir が別のエントリが
+# マニフェストに混在していても、down 呼び出しの総数は自リポジトリ分の2件のまま増えない。
+DOWN_TOTAL_COUNT="$(printf '%s\n' "$DOWN_ALL_LOG_CONTENT" | grep -c '^compose -p .* down$' || true)"
+assert_eq "compose: --down --all は同名別rootの混在があっても自リポジトリ分の2件だけを down する（issue #33）" \
+  "2" "$DOWN_TOTAL_COUNT"
+
+# --- issue #32 の直接検証: docker ps のフォーマットに .Label を使い、.Labels は使わない ---
+if printf '%s\n' "$DOWN_ALL_LOG_CONTENT" | grep -qF '.Label "com.docker.compose.project"'; then
+  pass "compose: docker ps のフォーマットに .Label を使う（issue #32）"
+else
+  fail "compose: docker ps のフォーマットに .Label を使う（issue #32）" "log=[${DOWN_ALL_LOG_CONTENT}]"
+fi
+
+if printf '%s\n' "$DOWN_ALL_LOG_CONTENT" | grep -qF 'index .Labels'; then
+  fail "compose: docker ps のフォーマットに index .Labels を使わない（issue #32）" "log=[${DOWN_ALL_LOG_CONTENT}]"
+else
+  pass "compose: docker ps のフォーマットに index .Labels を使わない（issue #32）"
+fi
+
+# --- issue #32: docker ps 失敗時は stderr に警告を出し、--ls 自体は非0で落ちない ---
+: > "$COMPOSE_PROJECTS_LOG"
+COMPOSE_PS_FAIL_STDERR="$(
+  cd "$COMPOSE_REPO" || exit 1
+  DW_COMPOSE_LOG="$COMPOSE_PROJECTS_LOG" \
+    DW_COMPOSE_SERVICE_STATE="$COMPOSE_PROJECTS_STATE" \
+    DW_COMPOSE_PROJECTS_MANIFEST="$COMPOSE_PROJECTS_MANIFEST_FILE" \
+    DW_COMPOSE_PS_FAIL=1 \
+    PATH="${FAKE_DOCKER_COMPOSE_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --ls 2>&1 1>/dev/null
+)"
+
+case "$COMPOSE_PS_FAIL_STDERR" in
+  *"WARNING"*"docker ps"*)
+    pass "compose: docker ps の失敗を握り潰さず stderr に警告する（issue #32）" ;;
+  *)
+    fail "compose: docker ps の失敗を握り潰さず stderr に警告する（issue #32）" \
+      "stderr=[${COMPOSE_PS_FAIL_STDERR}]" ;;
+esac
+
+COMPOSE_PS_FAIL_EXIT=0
+(
+  cd "$COMPOSE_REPO" || exit 1
+  DW_COMPOSE_LOG="$COMPOSE_PROJECTS_LOG" \
+    DW_COMPOSE_SERVICE_STATE="$COMPOSE_PROJECTS_STATE" \
+    DW_COMPOSE_PROJECTS_MANIFEST="$COMPOSE_PROJECTS_MANIFEST_FILE" \
+    DW_COMPOSE_PS_FAIL=1 \
+    PATH="${FAKE_DOCKER_COMPOSE_DIR}:${PATH}" \
+    bash scripts/sandbox-exec.sh --ls >/dev/null 2>&1
+)
+COMPOSE_PS_FAIL_EXIT=$?
+assert_exit_code "compose: docker ps の列挙に失敗しても --ls 自体は成功する（compose project欄なしで継続）" \
+  0 "$COMPOSE_PS_FAIL_EXIT"
 
 # ---------------------------------------------------------------------------
 # 結果集計

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -91,11 +91,18 @@ make_worktree() {
 copy_sandbox_scripts() {
   # copy_sandbox_scripts <dest_repo_dir>
   # sandbox-exec.sh / resolve-sandbox.sh / Dockerfile.dev を検証対象の一時リポジトリへ複製する。
+  # worktree はコミット済みの内容しか見えないため、複製後にコミットまで済ませる
+  # （worktree からもスクリプトを実行できるようにするため）。
   local dest="$1"
   mkdir -p "${dest}/scripts"
   cp "${REPO_ROOT}/scripts/sandbox-exec.sh"   "${dest}/scripts/sandbox-exec.sh"
   cp "${REPO_ROOT}/scripts/resolve-sandbox.sh" "${dest}/scripts/resolve-sandbox.sh"
   cp "${REPO_ROOT}/Dockerfile.dev"             "${dest}/Dockerfile.dev"
+  (
+    cd "$dest" || exit 1
+    git add scripts Dockerfile.dev
+    git commit -q -m "add sandbox scripts"
+  ) >/dev/null 2>&1
 }
 
 # ---------------------------------------------------------------------------
@@ -219,6 +226,98 @@ if [ -f "$DOCKER_CALLED_MARKER" ]; then
 else
   pass "--epic 付き --print-plan も docker を起動しない"
 fi
+
+# ---------------------------------------------------------------------------
+# ケース1〜6: パス解決とコンテナ名の一致（Epic #3 仕様書「5. 検証方針」のケース1〜6、Task #5）
+#
+# バインドマウント先をリポジトリルートに固定し、コンテナを epic 単位にする変更の検証。
+# リポジトリルート / epic worktree / agent worktree のいずれから叩いても
+# container が完全に一致し、workdir だけが相対パス分だけ変わることを確認する。
+# ---------------------------------------------------------------------------
+
+echo "== パス解決とコンテナ名（ケース1〜6） =="
+
+plan_value() {
+  # plan_value <key> <output>  出力から key=value の value 部分（先頭一致1件）を取り出す
+  printf '%s\n' "$2" | grep "^${1}=" | head -n1 | cut -d'=' -f2-
+}
+
+print_plan_in() {
+  # print_plan_in <dir> [追加の引数...]  <dir> で --print-plan を実行し出力全体を返す
+  local dir="$1"
+  shift
+  (
+    cd "$dir" || exit 1
+    PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan "$@"
+  )
+}
+
+# --- ケース1: リポジトリルートから ---
+CASE1_OUTPUT="$(print_plan_in "$PRINT_PLAN_REPO")"
+
+assert_eq "ケース1: rel_path は空" "" "$(plan_value rel_path "$CASE1_OUTPUT")"
+assert_eq "ケース1: fallback は0" "0" "$(plan_value fallback "$CASE1_OUTPUT")"
+assert_eq "ケース1: workdir は /workspace" "/workspace" "$(plan_value workdir "$CASE1_OUTPUT")"
+
+CASE1_CONTAINER="$(plan_value container "$CASE1_OUTPUT")"
+
+# --- ケース2: epic worktree（.claude/worktrees/epicN）から ---
+EPIC_WORKTREE_DIR="${PRINT_PLAN_REPO}/.claude/worktrees/epic5"
+make_worktree "$PRINT_PLAN_REPO" "$EPIC_WORKTREE_DIR" "epic-worktree-branch"
+
+CASE2_OUTPUT="$(print_plan_in "$EPIC_WORKTREE_DIR")"
+
+assert_eq "ケース2: rel_path は .claude/worktrees/epic5" ".claude/worktrees/epic5" "$(plan_value rel_path "$CASE2_OUTPUT")"
+assert_eq "ケース2: workdir は相対パス" "/workspace/.claude/worktrees/epic5" "$(plan_value workdir "$CASE2_OUTPUT")"
+assert_eq "ケース2: container はルート実行時と同一" "$CASE1_CONTAINER" "$(plan_value container "$CASE2_OUTPUT")"
+
+# --- ケース3: agent worktree（.claude/worktrees/agent-x）から ---
+AGENT_WORKTREE_DIR="${PRINT_PLAN_REPO}/.claude/worktrees/agent-x"
+make_worktree "$PRINT_PLAN_REPO" "$AGENT_WORKTREE_DIR" "agent-worktree-branch"
+
+CASE3_OUTPUT="$(print_plan_in "$AGENT_WORKTREE_DIR")"
+
+assert_eq "ケース3: rel_path は .claude/worktrees/agent-x" ".claude/worktrees/agent-x" "$(plan_value rel_path "$CASE3_OUTPUT")"
+assert_eq "ケース3: workdir は相対パス" "/workspace/.claude/worktrees/agent-x" "$(plan_value workdir "$CASE3_OUTPUT")"
+assert_eq "ケース3: container はケース1・2と同一" "$CASE1_CONTAINER" "$(plan_value container "$CASE3_OUTPUT")"
+
+# --- ケース4: --epic 無し + DEV_WORKFLOW_EPIC あり ---
+CASE4_OUTPUT="$(
+  cd "$PRINT_PLAN_REPO" || exit 1
+  DEV_WORKFLOW_EPIC=epic777 PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan
+)"
+assert_eq "ケース4: DEV_WORKFLOW_EPIC がコンテナ名に反映される" "${CASE1_CONTAINER}-epic777" "$(plan_value container "$CASE4_OUTPUT")"
+assert_eq "ケース4: epic の値も DEV_WORKFLOW_EPIC になる" "epic777" "$(plan_value epic "$CASE4_OUTPUT")"
+
+# --- ケース5: リポジトリ外の worktree（フォールバック） ---
+OUTSIDE_WORKTREE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-outside.XXXXXX")"
+make_worktree "$PRINT_PLAN_REPO" "$OUTSIDE_WORKTREE_DIR" "outside-worktree-branch"
+
+CASE5_STDERR="$(mktemp "${TMPDIR:-/tmp}/dw-test-case5-stderr.XXXXXX")"
+CASE5_OUTPUT="$(
+  cd "$OUTSIDE_WORKTREE_DIR" || exit 1
+  PATH="${FAKE_BIN_DIR}:${PATH}" bash scripts/sandbox-exec.sh --print-plan 2>"$CASE5_STDERR"
+)"
+
+assert_eq "ケース5: fallback は1" "1" "$(plan_value fallback "$CASE5_OUTPUT")"
+
+CASE5_CONTAINER="$(plan_value container "$CASE5_OUTPUT")"
+if [ "$CASE5_CONTAINER" != "$CASE1_CONTAINER" ]; then
+  pass "ケース5: container がリポジトリ共有コンテナと分離される"
+else
+  fail "ケース5: container がリポジトリ共有コンテナと分離される" "container=[${CASE5_CONTAINER}]（共有コンテナと同一でした）"
+fi
+
+if [ -s "$CASE5_STDERR" ]; then
+  pass "ケース5: フォールバック時に stderr へ警告する"
+else
+  fail "ケース5: フォールバック時に stderr へ警告する" "stderr が空でした"
+fi
+
+# --- ケース6: キャッシュ volume 名がリポジトリ単位である（worktree から叩いても変わらない） ---
+CASE1_CACHE="$(plan_value cache_volume "$CASE1_OUTPUT")"
+CASE3_CACHE="$(plan_value cache_volume "$CASE3_OUTPUT")"
+assert_eq "ケース6: cache_volume はリポジトリ単位（worktree から叩いても同じ）" "$CASE1_CACHE" "$CASE3_CACHE"
 
 # ---------------------------------------------------------------------------
 # 結果集計


### PR DESCRIPTION
## Summary

Closes #3

サンドボックスの分離単位を **epic** に統一し、「コンテナ数」「キャッシュの作用範囲」「後片付け」
「イメージの同一性」がすべて同じ単位で説明できる状態にする。あわせて compose モードの不具合と、
付随2件（可読性ガードのハング・CRLF）を解消する。

実運用の申し送りが指摘した **期待（epic 単位で分離）と実装（worktree 単位で分離＋
リポジトリ単位でキャッシュ共有）のずれ** を解消するもの。

### 分離単位（意図的に非対称）

| 対象 | 単位 | 命名 |
|---|---|---|
| コンテナ | **epic** | `dw-sandbox-<repo>-<epic>` |
| キャッシュ volume | **リポジトリ** | `dw-cache-<repo>-<path>` |
| イメージ | **Dockerfile 内容の hash** | `dev-sandbox:<repo>-<hash8>` |

キャッシュをリポジトリ単位に据え置いたのは、それが v0.10.0 の性能改善の本体（40秒→17秒）であり、
epic 単位にすると新しい epic が毎回コールドスタートに戻るため。非対称であることの唯一の実害である
`--reset-cache` の誤爆は、列挙表示・running 検出・`--force` のガードで潰した。

## 完了タスク

### Phase 1: 検証基盤
- [x] #4 テスト基盤・`Dockerfile.dev`・`--print-plan` の骨格

### Phase 2: 分離単位とライフサイクル
- [x] #5 リポジトリルートマウントと epic 単位のコンテナ
- [x] #6 docker label と後片付け（`--ls` / `--down` / `--down --all`）
- [x] #7 `--reset-cache` のガード（列挙・running 検出・`--force`）

### Phase 3: イメージと compose
- [x] #8 イメージ責務の集約（自動ビルド・hash タグ・`--rebuild`）
- [x] #9 compose モードの修正（`-p` / `--project-directory` / 自動 up / 衝突検出）

### Phase 4: 付随の2件
- [x] #10 `check-readability.sh` の非対話ハング修正
- [x] #11 CRLF 警告と generator の生成規約

### Phase 5: 反映とリリース
- [x] #12 run スキル2本の更新
- [x] #13 ドキュメント更新と v0.11.0

## レビュー結果

一括レビュー2巡（evaluator）。**指摘11件すべて対応済み**。

### 1巡目（`ab4e977`）— high 2 / medium 5
- [x] #25 マウント元比較が Docker Desktop の変換済みパスと不一致（**high**）
- [x] #26 evaluator 役割定義が旧タグで静かに検証する（**high**）
- [x] #27 compose がフォールバック時に project 名を分離せず別ツリーに exec
- [x] #28 compose コンテナを落とす手段が無く新たなリーク
- [x] #29 所属判定が basename のみで同名別リポジトリを巻き込む
- [x] #30 マウント元不一致の再作成と label 付与が未テスト
- [x] #31 可読性ガードが1行しか読まず複数行JSONで素通り

### 2巡目（`d48ce81`）— high 2 / medium 2
- [x] #32 compose の `--down --all` / `--ls` が `docker ps` のテンプレート誤用で常に無反応（**high**）
- [x] #33 compose の `--down --all` が接頭辞一致で他リポジトリの project を巻き込む（**high**）
- [x] #34 compose の `--down --all` / `--ls` にテストが1件も無い
- [x] #35 外部 `timeout` 依存で macOS の可読性ガードが全件素通り

### レビューで挙がった軽微な指摘（issue 化せず記録のみ）

- `--reset-cache` が現在の repo+epic のコンテナも削除する点が README のライフサイクル表に未記載
- 固定ホストポートの検出が short syntax（`- "8080:80"`）のみで、long syntax（`published:`）や
  変数展開（`- "${PORT}:80"`）を拾わない（警告のみの機能なので実害は小さい）
- `normalize_mount_source` の小文字化は、case-sensitive な Linux で `/mnt/c/Foo` と `/mnt/c/foo` が
  実在する場合に同一視し得る（レビュアー自身が「現状の設計は妥当」と判断。対応不要）

## Test plan

- [x] `tests/run-tests.sh`: **215 passed / 0 failed / 0 skipped**（新規。Docker 非依存）
- [x] `adapters/claude/build.sh --check` / `adapters/codex/build.sh --check`: 両方 OK
- [x] 可読性ガード `check-readability.sh --git`: exit 0
- [x] 上記すべてを Docker sandbox 内で実行（ホストには shellcheck が無いため）

### 実機での確認（受け入れ条件の裏取り）

```
# 受け入れ条件1: worktree が変わってもコンテナ名が同一
epic worktree から  : container=dw-sandbox-dev-workflow-epic3 workdir=/workspace/.claude/worktrees/epic3
リポジトリルートから: container=dw-sandbox-dev-workflow-epic3 rel_path=

# 受け入れ条件2: 旧命名の残骸を回収できる（レビュー時は NOT MATCHED だった）
docker が返す実値: /run/desktop/mnt/host/c/Users/.../dev-workflow/.claude/worktrees/epic3
正規化後        : C:/users/mimay/documents/github/dev-workflow/.claude/worktrees/epic3
→ MATCHED（--down --all で回収できる）

# #33: 他リポジトリの compose project を巻き込まない
ホスト上に稼働中の他リポジトリ compose project 9件以上（kikumemo-api, casting_ai, ...）
→ working_dir ベース判定で対象 0件

# #10/#31/#35: ハングせず、かつ複数行JSONを検出する
timeout 8 bash scripts/check-readability.sh --git < <(sleep 30) → exit=0 elapsed=0s
bash scripts/check-readability.sh < 複数行hook.json              → exit=2（検出）
（v0.10.0 は前者が exit=124 でハングしていた）
```

## 注意点（レビュアー向け）

- **ベースブランチは `master`**（このリポジトリの既定ブランチ。`main` は存在しない）
- `.gitattributes` に `*.toml` と自己参照の `eol=lf` を追加した。**属性追加は既存のワーキングツリーを
  遡って直さない**ため、既存クローンでは `git rm --cached -r . && git reset --hard` による
  再正規化が必要（内容差分は出ない）。README に明記済み
- イメージタグが `dev-sandbox:<repo>` → `dev-sandbox:<repo>-<hash8>` に変わるため初回に1度だけ再ビルドが走る。
  旧タグは残るので、不要なら利用者が削除する（本 PR では削除しない）
- **既存の残骸コンテナは本 PR では自動削除しない。** マージ後に `--down --all` を明示実行すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
