### PR TITLE
fix: Epic #122 のレビュー残指摘4件を解消する

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,10 +928,11 @@ https://hooks.slack.com/services/XXX/YYY/ZZZ
 | `none` | メンションなし |
 | `<@U123ABC>` | 特定ユーザーへのメンション（SlackのメンバーID） |
 
-3. `.claude/slack-webhook` はWebhook URLという秘密情報を含むため、`.gitignore` には追加しない。
-   `.git/info/exclude`（コミットされないローカル除外設定）で自動的に除外される。**`.gitignore`
-   は駆動先チームの共有ファイルなので触らない**（上記「ハーネス非注入原則」参照）。この整備は
-   `scripts/check-repo-hygiene.sh` が SessionStart のたびに冪等に行う
+3. `.claude/slack-webhook` は `.gitignore` に追加しない。ハーネス生成物の除外は、コミットされない
+   ローカル設定である `.git/info/exclude` で行う（**`.gitignore` は駆動先チームの共有ファイルなので
+   触らない** — 上記「ハーネス非注入原則」参照）。この整備は `scripts/check-repo-hygiene.sh` が
+   SessionStart のたびに冪等に行うため、手作業は不要である。なお Webhook URL は秘密情報なので、
+   除外方法にかかわらずコミットしないこと
 
 環境変数 `SLACK_WEBHOOK_URL` / `DEV_WORKFLOW_PROJECT_NAME` でも指定できる（ファイル設定が優先）。メンションは `DEV_WORKFLOW_SLACK_MENTION` で上書きでき、こちらはファイル設定より優先される。
 

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -170,12 +170,18 @@ if [ "$NEW_CONTENT" != "$OLD_CONTENT" ]; then
       :
     else
       EXCLUDE_WRITE_FAILED=1
+      # mv が失敗した場合に限り一時ファイルが残る。削除コマンドは使えないので、
+      # 中身を空にして紛らわしい複製を残さず、パスを警告に載せて人間に委ねる。
+      [ -f "$EXCLUDE_TMP" ] && : > "$EXCLUDE_TMP" 2>/dev/null
     fi
   fi
 fi
 
 if [ "$EXCLUDE_WRITE_FAILED" -eq 1 ]; then
   echo "[dev-workflow] 警告: ${EXCLUDE_FILE} への書き込みに失敗しました。手動で整備してください。" >&2
+  if [ -f "${EXCLUDE_TMP:-}" ]; then
+    echo "[dev-workflow]   空の一時ファイルが残っています（不要なら削除してください）: ${EXCLUDE_TMP}" >&2
+  fi
 elif [ "$EXCLUDE_UPDATED" = "yes" ]; then
   if [ "$CHECK_MODE" -eq 1 ]; then
     echo "[dev-workflow] 情報: ${EXCLUDE_FILE} の更新が必要です（--check のため書き込みません）。" >&2

--- a/scripts/resolve-sandbox.sh
+++ b/scripts/resolve-sandbox.sh
@@ -41,8 +41,10 @@
 #
 # ビルドコンテキストの解決順（仕様書 4.2）:
 #   1. DEV_WORKFLOW_DOCKER_BUILD_CONTEXT が非空 -> その値（正規化して採用）
-#   2. 解決した Dockerfile がリポジトリルート配下に無い -> リポジトリルート
-#   3. それ以外 -> dirname(Dockerfile)（既存挙動）
+#   2. 解決した Dockerfile がリポジトリルート配下にある -> dirname(Dockerfile)（既存挙動）
+#   3. リポジトリルート配下に無いがカレントディレクトリ配下にある -> dirname(Dockerfile)
+#      （sandbox-exec.sh がカレントをマウント元にするフォールバック経路と揃える）
+#   4. それ以外（規約パス等） -> リポジトリルート
 #
 # イメージタグの hash について（仕様書 4.7）:
 #   Dockerfile.dev からビルドする場合、タグは dev-sandbox:<repo>-<hash8> とする。
@@ -122,7 +124,20 @@ resolve_build_context() {
         return 0
         ;;
       *)
-        # リポジトリルート配下に無い（規約パス等）-> リポジトリルートを使う
+        # リポジトリルート配下に無い。ただしカレントディレクトリ配下にある場合は
+        # そちらを使う。sandbox-exec.sh はカレントがリポジトリルート外のとき
+        # （リポジトリ外に作られた兄弟 worktree 等）カレントをマウント元にするため、
+        # ここでリポジトリルートを返すとマウント元とビルドコンテキストが食い違い、
+        # COPY がメインリポ側の内容を拾ってしまう。
+        local cur_norm
+        cur_norm="$(normalize_dir "$(pwd)")"
+        case "$dockerfile_dir" in
+          "$cur_norm"|"${cur_norm}"/*)
+            printf '%s' "$dockerfile_dir"
+            return 0
+            ;;
+        esac
+        # カレント配下でもない（規約パス等）-> リポジトリルートを使う
         printf '%s' "$repo_root_norm"
         return 0
         ;;

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -10067,7 +10067,9 @@ assert_eq "check-repo-hygiene.sh: 複数START_MARKER時、2つめのSTART_MARKER
 #     決定論的に再現できるようにする。permission ビットには依存しない） ---
 HYG_REPO8="$(make_temp_repo)"
 HYG_GITDIR8="${HYG_REPO8}/.git"
-rm -rf -- "${HYG_GITDIR8}/info" 2>/dev/null
+# 削除コマンドは使わず mv で横へ退避する（このファイル冒頭の make_temp_repo の規約に従う）。
+# git init 直後の .git/info には exclude しか無く、退避しても以降の検証に影響しない。
+mv -- "${HYG_GITDIR8}/info" "${HYG_GITDIR8}/info.orig" 2>/dev/null
 printf 'not-a-directory\n' > "${HYG_GITDIR8}/info"
 
 HYG_FAILWRITE_OUT="$( cd "$HYG_REPO8" && bash "$HYG_SCRIPT" 2>&1 )"
@@ -11328,6 +11330,24 @@ assert_eq "DEV_WORKFLOW_DOCKER_BUILD_CONTEXT指定時はその値が採用され
   "$(normalize_test_path "$RS6_CUSTOM_CONTEXT")" "$(plan_value DEV_WORKFLOW_SANDBOX_CONTEXT "$RS6_OUTPUT")"
 
 # --- 受け入れ条件7: 規約パスにも何も無ければ mode=none のまま ---
+# --- リポジトリ外に作られた兄弟 worktree 内の Dockerfile では、build context を
+#     リポジトリルートではなくその worktree にする（sandbox-exec.sh がカレントを
+#     マウント元にするフォールバック経路と揃える。#122一括レビュー指摘、由来: #123） ---
+RS6B_REPO="$(make_temp_repo)"
+RS6B_OUTSIDE="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-sibling.XXXXXX")/wt"
+make_worktree "$RS6B_REPO" "$RS6B_OUTSIDE" "sibling-wt"
+cat > "${RS6B_OUTSIDE}/Dockerfile.dev" <<'EOF'
+FROM alpine
+EOF
+
+RS6B_OUTPUT="$(
+  cd "$RS6B_OUTSIDE" || exit 1
+  bash "$RESOLVE_SANDBOX_SCRIPT"
+)"
+
+assert_eq "リポジトリ外の兄弟worktree内Dockerfile: build contextはその worktree になる（マウント元と一致）" \
+  "$(normalize_test_path "$RS6B_OUTSIDE")" "$(plan_value DEV_WORKFLOW_SANDBOX_CONTEXT "$RS6B_OUTPUT")"
+
 RS7_REPO="$(make_temp_repo)"
 RS7_NAME="$(basename "$RS7_REPO")"
 RS7_HOME="$(mktemp -d "${TMPDIR:-/tmp}/dw-test-sandboxhome.XXXXXX")"


### PR DESCRIPTION
## Summary
Closes #135

PR #136 は `be2fa2c` 時点でマージされたため、その後に push した修正コミット `ca06da7` が master に取り込まれていませんでした。本 PR はその1コミットのみを追随させます。

| 指摘 | 対応 |
|---|---|
| #135 テストが規約違反の `rm -rf` を持ち込んでいる | `mv` による退避に置き換え。`make_temp_repo` の規約（削除コマンドを実行しない）に戻し、mktemp 失敗時に `rm -rf -- "/.git"` が走る穴も解消 |
| 兄弟 worktree（リポジトリ外）の Dockerfile でビルドコンテキストがメインリポルートへ変わる | `resolve_build_context()` に「リポジトリルート外でもカレント配下ならそのディレクトリ」の規則を追加し、`sandbox-exec.sh` がカレントをマウント元にするフォールバック経路と一致させた。回帰テストを追加（リポジトリ内 Dockerfile・規約パスの挙動は不変） |
| exclude 書き込みの mv 失敗時に一時ファイルが残りうる | 残った一時ファイルを空にし、パスを警告に載せて人間の判断に委ねる（削除コマンドは使わない） |
| README:931 の理由づけが一読で逆接に読める | 「ハーネス非注入原則により `.gitignore` は触らない」を理由として明示し、Webhook URL が秘密情報である旨は独立した注意として残した |

## Test plan
- [x] Docker sandbox 内で全テスト通過: **1287 passed / 0 failed / 0 skipped**（SKIP件数は `count-skips.sh` で機械検証）
- [x] `adapters/claude/build.sh --check` / `adapters/codex/build.sh --check` とも OK
- [x] 可読性ガード通過、削除コマンドの混入なしを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)