### PR TITLE
release: v0.18.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "dev-workflow",
   "displayName": "Dev Workflow",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "3エージェント自律開発ワークフロー。Docker sandbox内でplanner・generator・evaluatorによる仕様策定から自律実装まで。",
   "author": {
     "name": "masatoImayama",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-workflow",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "3エージェント自律開発ワークフロー。planner・generator・evaluatorが仕様策定から自律実装までを担う。",
   "author": {
     "name": "masatoImayama",

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -6779,13 +6779,13 @@ DOC55_README="${REPO_ROOT}/README.md"
 DOC55_AGENT_GENERATOR="${REPO_ROOT}/agents/generator.md"
 DOC55_CODEX_AGENT_GENERATOR="${REPO_ROOT}/codex-agents/generator.toml"
 
-# --- 両 plugin.json のバージョンが 0.17.0 で一致している（#122 でマイナー更新） ---
+# --- 両 plugin.json のバージョンが 0.18.0 で一致している（#143 #173 #174 でマイナー更新） ---
 
 DOC55_CLAUDE_VERSION="$(grep -m1 '"version"' "$DOC55_CLAUDE_PLUGIN_JSON" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
 DOC55_CODEX_VERSION="$(grep -m1 '"version"' "$DOC55_CODEX_PLUGIN_JSON" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
 
-assert_eq ".claude-plugin/plugin.json のバージョンが0.17.0である" "0.17.0" "$DOC55_CLAUDE_VERSION"
-assert_eq ".codex-plugin/plugin.json のバージョンが0.17.0である" "0.17.0" "$DOC55_CODEX_VERSION"
+assert_eq ".claude-plugin/plugin.json のバージョンが0.18.0である" "0.18.0" "$DOC55_CLAUDE_VERSION"
+assert_eq ".codex-plugin/plugin.json のバージョンが0.18.0である" "0.18.0" "$DOC55_CODEX_VERSION"
 assert_eq "両plugin.jsonのバージョンが一致している" "$DOC55_CLAUDE_VERSION" "$DOC55_CODEX_VERSION"
 
 # --- core/instructions.md に watchdog の3点の記述がある ---


### PR DESCRIPTION
## Summary

`.claude-plugin/plugin.json` と `.codex-plugin/plugin.json` のバージョンを **0.17.0 → 0.18.0** に上げ、`tests/run-tests.sh` のバージョン固定アサーションを追随させる。

3 files changed（バージョン文字列のみ）

## v0.17.0 以降に入った変更

| Epic / issue | 内容 |
|---|---|
| **Epic #143** | run の実行時間短縮 — 統合ゲートの Epic 末集約、プロンプトの progressive disclosure、観点別レビューの並列化、編集時チェックフック、generator への LSP 付与、evaluator のモデル分離 |
| **Epic #173** | Windows/Docker バインドマウントでのレーン成立性 — `share-prepared-dirs.sh` の共有失敗パス修正（#117 / #118）とコピー・フォールバック（#139） |
| **Epic #174** | 駆動先で run が止まらず・誤判定しないようにする — 承認プロンプト誘発の解消（#140）、`count-skips.sh` の jest 誤検出（#142）、`check-readability.sh` の `generated/` 誤検知（#141） |
| **#197** | レビュー指摘対応時に「守るべき性質」の言語化を促し、不変条件レベルの検査へ昇格させる |
| **#176（部分）** | 合成 node プロジェクトの fixture 生成スクリプト |

テストは **1291 → 1836 件**（+545）に増えた。

## ⚠️ 併せて確認をお願いしたいこと

**v0.16.0 と v0.17.0 は、バージョンを上げるコミットはあるが git タグも GitHub リリースも作られていない。**

```
plugin.json のバージョン : 0.17.0（→ 本 PR で 0.18.0）
git タグの最新           : v0.15.0
GitHub リリースの最新    : v0.15.0
```

| バージョン | release コミット | git タグ | GitHub リリース |
|---|---|---|---|
| v0.15.0 | `2e01d9d` | ✅ | ✅ |
| v0.16.0 | `b55d98a` | ❌ | ❌ |
| v0.17.0 | `8c72937` | ❌ | ❌ |
| v0.18.0 | 本 PR | 本 PR マージ後に作成予定 | 同左 |

本 PR のマージ後に **v0.18.0 のタグとリリースは作成する**が、**v0.16.0 / v0.17.0 を遡って打つかは判断が要る**ため触っていない。

## Test plan
- [x] 全テスト通過確認済み（Docker sandbox 内・1836 passed / 0 failed / 0 skipped）
- [x] `adapters/claude/build.sh --check` / `adapters/codex/build.sh --check` 通過
- [x] 両 `plugin.json` のバージョン一致テスト（#77）とバージョン値の固定テスト（#55）が新しい値で通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)